### PR TITLE
Improve Video type - Fix issue 6

### DIFF
--- a/classes/Video.js
+++ b/classes/Video.js
@@ -141,7 +141,6 @@ class Video {
         if(this.videoType === VideoTypes.EMBED || this.videoType === VideoTypes.RTMP) {
             this.url = this.data.url;
         }
-        delete this.data;
     }
 
     /**

--- a/classes/Video.js
+++ b/classes/Video.js
@@ -132,6 +132,19 @@ class Video {
     }
 
     /**
+     * Unpack the data in {@link this.data} to comply with the more structured system in GraphQL.
+     * The reason for this design choice is unfortunately Javascript classes are kind of wonky...
+     * I believe it would be difficult to maintain an inheritance-based structure for Videos in JS.
+     * Could always change later.
+     */
+    unpackForClient() {
+        if(this.videoType === VideoTypes.EMBED || this.videoType === VideoTypes.RTMP) {
+            this.url = this.data.url;
+        }
+        delete this.data;
+    }
+
+    /**
      * Get a Video from the database, given its unique ID.
      * @param id {number} ID to search for in the database
      * @returns {Promise<null|Video>} The fetched Video, or null if the Video does not exist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,18 +25,18 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+          "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
         }
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.3.tgz",
-      "integrity": "sha512-CtC1bmohB1owdGMT2ZZKacI94LcPAZDN2WvCe+4ZXT5d7xO5PHOAb70EP/LcFbvnS8QI+pkYRSCGFQnUcv9efg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.5.tgz",
+      "integrity": "sha512-KOZC4Y+JM4iQQ7P4CVC878Ee7ya0QoHApGHu4klwjwZkYyOdWIvbML7JfXOUb/AfCO4DFmJfHCjRdAX09Ga6sQ==",
       "requires": {
-        "apollo-env": "^0.6.1"
+        "apollo-env": "^0.6.2"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -123,6 +123,11 @@
         "@types/node": "*"
       }
     },
+    "@types/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
+    },
     "@types/cookies": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
@@ -143,9 +148,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
+      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -153,9 +158,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
+      "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -200,11 +205,12 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.2.tgz",
-      "integrity": "sha512-2UPelagNNW6bnc1I5kIzluCaheXRA9S+NyOdXEFFj9Az7jc15ek5V03kb8OTbb3tdZ5i2BIJObe86PhHvpMolg==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
+      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
       "requires": {
         "@types/accepts": "*",
+        "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
         "@types/keygrip": "*",
@@ -236,11 +242,12 @@
       "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
     },
     "@types/node-fetch": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
-      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
       }
     },
     "@types/range-parser": {
@@ -275,9 +282,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -297,12 +304,12 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "apollo-cache-control": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-      "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.1.tgz",
+      "integrity": "sha512-9t2EcRevUrANuGhF5XUbKJEfnc6Jy2Rn7Y8nOIKlsEEC+AX7Ko4svWYTyyTxj0h0RXfiegY2nbz4sVry/pS3rA==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.11.1"
       }
     },
     "apollo-datasource": {
@@ -315,18 +322,18 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
-      "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.1.tgz",
+      "integrity": "sha512-9ykddPxlC95R9CkkJaPaGriRbOGfzeKqqPXRAunyX1h4sG/8g+MJ/gGzmnNf63k6RvRUdRENCE83wPk2OeU+2A==",
       "requires": {
         "apollo-engine-reporting-protobuf": "^0.4.4",
         "apollo-graphql": "^0.4.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-types": "^0.3.1",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.11.1"
       }
     },
     "apollo-engine-reporting-protobuf": {
@@ -338,34 +345,34 @@
       }
     },
     "apollo-env": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.1.tgz",
-      "integrity": "sha512-B9BgpQGR1ndeDtb4Gtor0J4CITQ+OPACZrVW6lgStnljKEe9ZB76DZ1dAd3OCeizAswW6Lo9uvfK8jhVS5nBhQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
+      "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
       "requires": {
-        "@types/node-fetch": "2.5.4",
+        "@types/node-fetch": "2.5.5",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.0.tgz",
-      "integrity": "sha512-abCHcKln1EGbzSItW087EjBI5wnluikyUqEn4VsdeWHCtdENWpHCn/MnM0+jJa1prNasxN7tCukp4nMpJYYVqg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
+      "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
       "requires": {
-        "apollo-env": "^0.6.1",
+        "apollo-env": "^0.6.2",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-link": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.20"
+        "zen-observable-ts": "^0.8.21"
       }
     },
     "apollo-server-caching": {
@@ -377,28 +384,29 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
-      "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.12.0.tgz",
+      "integrity": "sha512-BRVdOyZrRJ1ALlmis0vaOLIHHYu5K3UVKAQKIgHkRh/YY0Av4lpeEXr49ELK04LTeh0DG0pQ5YYYhaX1wFcDEw==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/graphql-upload": "^8.0.0",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "^0.9.0",
+        "apollo-cache-control": "^0.9.1",
         "apollo-datasource": "^0.7.0",
-        "apollo-engine-reporting": "^1.7.0",
+        "apollo-engine-reporting": "^1.7.1",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-plugin-base": "^0.7.0",
-        "apollo-server-types": "^0.3.0",
-        "apollo-tracing": "^0.9.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.7.1",
+        "apollo-server-types": "^0.3.1",
+        "apollo-tracing": "^0.9.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.11.0",
+        "graphql-extensions": "^0.11.1",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
+        "loglevel": "^1.6.7",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
@@ -414,23 +422,23 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-      "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
+      "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
     },
     "apollo-server-express": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.11.0.tgz",
-      "integrity": "sha512-9bbiD+zFAx+xyurc9lxYmNa9y79k/gsA1vEyPFVcv7jxzCFC5wc0tcbV7NPX2qi1Nn7K76fxo2fPNYbPFX/y0g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.12.0.tgz",
+      "integrity": "sha512-oTBKM2SsziCoFW+ta+ubJ/ypvsc+EWrbJnyZhJ5FBYzSXPstt/jvgZHgMO+kOQgHEHrbJwugNDUuLMSm608L7A==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "^2.8.4",
-        "@types/express": "4.17.2",
+        "@types/express": "4.17.3",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.11.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-core": "^2.12.0",
+        "apollo-server-types": "^0.3.1",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -442,17 +450,17 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-      "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.1.tgz",
+      "integrity": "sha512-PRavvoWq7/Xufqc+qkDQg3Aqueq4QrPBFfoCFIjhkJ4n2d2YoqE3gTGccb8YoWusfa62ASMn6R47OdNuVtEbXw==",
       "requires": {
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.3.1"
       }
     },
     "apollo-server-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-      "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.1.tgz",
+      "integrity": "sha512-6nX5VC3icOGf1RZIs7/SYQZff+Cl16LQu1FHUOIk9gAMN2XjlRCyJgCeMj5YHJzQ8Mhg4BO0weWuydEg+JxLzg==",
       "requires": {
         "apollo-engine-reporting-protobuf": "^0.4.4",
         "apollo-server-caching": "^0.5.1",
@@ -460,12 +468,12 @@
       }
     },
     "apollo-tracing": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
-      "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.1.tgz",
+      "integrity": "sha512-4wVNM6rc70XhwWxuDWrMBLaHA8NjB9pUS2sNpddQvP36ZtQfsa08XLSUxGAZT+bej+TzW26hKNtuO31RgqC9Hg==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.11.1"
       }
     },
     "apollo-utilities": {
@@ -511,17 +519,29 @@
         "retry": "0.12.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -570,6 +590,15 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
+      }
+    },
+    "buffer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-writer": {
@@ -631,6 +660,14 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -667,9 +704,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -713,6 +750,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -771,9 +813,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -881,6 +923,16 @@
         "unpipe": "~1.0.0"
       }
     },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -958,13 +1010,13 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-      "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.1.tgz",
+      "integrity": "sha512-1bstq6YKaC579PTw9gchw2VlXqjPo3vn8NjRMaUqF2SxyYTjVSgXaCAbaeNa0B7xlLVigxi3DV1zh4A+ss+Lwg==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.3.1"
       }
     },
     "graphql-scalars": {
@@ -1056,6 +1108,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1133,6 +1190,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
+    "loglevel": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -1185,9 +1247,9 @@
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",
@@ -1221,19 +1283,17 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
     },
     "ms": {
       "version": "2.0.0",
@@ -1718,22 +1778,42 @@
         "strip-ansi": "^3.0.0"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -1817,22 +1897,22 @@
       }
     },
     "tar-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
       "requires": {
         "chownr": "^1.1.1",
-        "mkdirp": "^0.5.1",
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^2.0.0"
       }
     },
     "tar-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
       "requires": {
-        "bl": "^3.0.0",
+        "bl": "^4.0.1",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -1974,9 +2054,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/postgres-init.js
+++ b/postgres-init.js
@@ -31,7 +31,7 @@ const schema = Object.freeze({
     videos: {
         id: 'serial not null primary key',
         name: 'varchar(128) not null',
-        video_type: 'varchar(32) not null default "RTMP"', // TODO could be changed to enum
+        video_type: 'varchar(32) not null default \'RTMP\'', // TODO could be changed to enum
         data: 'json not null'
     },
     images: {

--- a/postgres-init.js
+++ b/postgres-init.js
@@ -31,7 +31,7 @@ const schema = Object.freeze({
     videos: {
         id: 'serial not null primary key',
         name: 'varchar(128) not null',
-        video_type: 'int not null default 0',
+        video_type: 'varchar(32) not null default "RTMP"', // TODO could be changed to enum
         data: 'json not null'
     },
     images: {

--- a/resolvers.js
+++ b/resolvers.js
@@ -225,22 +225,50 @@ const resolvers = {
             }
             return null;
         },
-        createVideo: async (obj, args) => {
-            return Video.createVideo(args.name, args.videoType, args.data);
+        createEmbedVideo: async (obj, args) => {
+            return Video.createEmbedVideo(args.name, args.url);
         },
-        updateVideo: async (obj, args) => {
+        createRTMPVideo: async (obj, args) => {
+            return Video.createRTMPVideo(args.name, args.rtmpUrl);
+        },
+        updateEmbedVideo: async (obj, args) => {
             const video = await Video.getVideoFromId(args.id);
             if(video == null) {
                 throw new Error('Video with the provided \'id\' does not exist!');
             }
+            if(video.videoType !== "EMBED") {
+                throw new Error('Video with the provided \'id\' is not an embed-type Video!');
+            }
             if(args.name !== undefined) {
                 video.name = args.name;
             }
-            if(args.videoType !== undefined) {
-                video.videoType = args.videoType;
+            if(args.url !== undefined) {
+                if(!args.url.match(/^https?:\/\//)) {
+                    throw new Error("Malformed url: Beginning must match \"https?:\\/\\/\"!")
+                }
+                video.data.url = args.url;
             }
-            if(args.data !== undefined) {
-                video.data = args.data;
+            if(await video.save())
+                return video;
+            return null;
+
+        },
+        updateRTMPVideo: async (obj, args) => {
+            const video = await Video.getVideoFromId(args.id);
+            if(video == null) {
+                throw new Error('Video with the provided \'id\' does not exist!');
+            }
+            if(video.videoType !== "RTMP") {
+                throw new Error('Video with the provided \'id\' is not an RTMP-type Video!');
+            }
+            if(args.name !== undefined) {
+                video.name = args.name;
+            }
+            if(args.rtmpUrl !== undefined) {
+                if(!args.rtmpUrl.startsWith("rtmp://")) {
+                    throw new Error("Malformed rtmpUrl: Must begin with \"rtmp://\"!")
+                }
+                video.data.rtmpUrl = args.rtmpUrl;
             }
             if(await video.save())
                 return video;

--- a/resolvers.js
+++ b/resolvers.js
@@ -2,7 +2,7 @@ const { Person } = require('./classes/Person');
 const { User } = require('./classes/User');
 const { Role } = require('./classes/Role');
 const { Image } = require('./classes/Image');
-const { Video } = require('./classes/Video');
+const { Video, VideoTypes } = require('./classes/Video');
 const { Production } = require('./classes/Production');
 const { Category } = require('./classes/Category');
 const { Credit } = require('./classes/Credit');
@@ -25,7 +25,11 @@ const resolvers = {
             return Image.getPaginatedImages(args.pageSize, args.prevImageIndex);
         },
         videos: async (obj, args) => {
-            return Video.getPaginatedVideos(args.pageSize, args.prevVideoIndex);
+            const vids = await Video.getPaginatedVideos(args.pageSize, args.prevVideoIndex);
+            for(let i = 0; i < vids.length; i++) {
+                vids[i].unpackForClient();
+            }
+            return vids;
         },
         productions: async (obj, args) => {
             return Production.getPaginatedProductions(args.pageSize, args.prevProductionIndex);
@@ -47,7 +51,9 @@ const resolvers = {
             return Image.getImageFromId(args.id);
         },
         getVideo: async (obj, args) => {
-            return Video.getVideoFromId(args.id);
+            const vid = await Video.getVideoFromId(args.id);
+            vid.unpackForClient();
+            return vid;
         },
         getProduction: async (obj, args) => {
             return Production.getProductionFromId(args.id);
@@ -98,7 +104,11 @@ const resolvers = {
     },
     Production: {
         videos: async (obj) => {
-            return obj.getProductionVideos();
+            const vids = await obj.getProductionVideos();
+            for(let i = 0; i < vids.length; i++) {
+                vids[i].unpackForClient();
+            }
+            return vids;
         },
         images: async (obj) => {
             return obj.getProductionImages();
@@ -130,6 +140,16 @@ const resolvers = {
         },
         appearsAfter: async (obj) => {
             return obj.getPreviousCategory();
+        }
+    },
+    Video: {
+        __resolveType(vid) {
+            switch(vid.videoType) {
+                case VideoTypes.EMBED:
+                    return "EmbedVideo";
+                case VideoTypes.RTMP:
+                    return "RTMPVideo"
+            }
         }
     },
 
@@ -226,17 +246,21 @@ const resolvers = {
             return null;
         },
         createEmbedVideo: async (obj, args) => {
-            return Video.createEmbedVideo(args.name, args.url);
+            const vid = await Video.createEmbedVideo(args.name, args.url);
+            vid.unpackForClient();
+            return vid;
         },
         createRTMPVideo: async (obj, args) => {
-            return Video.createRTMPVideo(args.name, args.rtmpUrl);
+            const vid = await Video.createRTMPVideo(args.name, args.rtmpUrl);
+            vid.unpackForClient();
+            return vid;
         },
         updateEmbedVideo: async (obj, args) => {
             const video = await Video.getVideoFromId(args.id);
             if(video == null) {
                 throw new Error('Video with the provided \'id\' does not exist!');
             }
-            if(video.videoType !== "EMBED") {
+            if(video.videoType !== VideoTypes.EMBED) {
                 throw new Error('Video with the provided \'id\' is not an embed-type Video!');
             }
             if(args.name !== undefined) {
@@ -248,8 +272,10 @@ const resolvers = {
                 }
                 video.data.url = args.url;
             }
-            if(await video.save())
+            if(await video.save()) {
+                video.unpackForClient();
                 return video;
+            }
             return null;
 
         },
@@ -258,7 +284,7 @@ const resolvers = {
             if(video == null) {
                 throw new Error('Video with the provided \'id\' does not exist!');
             }
-            if(video.videoType !== "RTMP") {
+            if(video.videoType !== VideoTypes.RTMP) {
                 throw new Error('Video with the provided \'id\' is not an RTMP-type Video!');
             }
             if(args.name !== undefined) {
@@ -268,10 +294,12 @@ const resolvers = {
                 if(!args.rtmpUrl.startsWith("rtmp://")) {
                     throw new Error("Malformed rtmpUrl: Must begin with \"rtmp://\"!")
                 }
-                video.data.rtmpUrl = args.rtmpUrl;
+                video.data.url = args.rtmpUrl;
             }
-            if(await video.save())
+            if(await video.save()) {
+                video.unpackForClient();
                 return video;
+            }
             return null;
 
         },

--- a/schema.js
+++ b/schema.js
@@ -9,6 +9,11 @@ const typeDefs = gql`
     scalar DateTime
     scalar JSON
     
+    enum VideoType {
+        EMBED,
+        RTMP
+    }
+    
     type Query {
         """
         Get a list of all User objects in a paginated or non-paginated manner.
@@ -147,16 +152,26 @@ const typeDefs = gql`
         Update an image in the database.
         """
         updateImage(id: Int!, name: String): Image
-        
+
         """
-        Create a new video in the database. Takes a loosely-defined JSON data value which contains the video's metadata.
-        TODO should be improved to have different methods for different types of videos.
+        Create a new embed-based video in the database. Requires a url that begins with "http://" or "https://".
         """
-        createVideo(name: String!, videoType: Int!, data: JSON!): Video # TODO Improve syntax
+        createEmbedVideo(name: String!, url: String!): Video
         """
-        Update a video in the database.
+        Create a new RTMP-based video in the database. Requires a url that begins with "rtmp://". RTMP requires
+        Flash Player, and as such, this type of video should soon be deprecated.
         """
-        updateVideo(id: Int!, name: String, videoType: Int, data: JSON): Video
+        createRTMPVideo(name: String!, rtmpUrl: String!): Video
+        """
+        Update an embed-based video in the database.
+        If the video with the provided ID is not an embed video, an error will be thrown.
+        """
+        updateEmbedVideo(id: Int!, name: String, url: String): Video
+        """
+        Update an RTMP-based video in the database. 
+        If the video with the provided ID is not an RTMP video, an error will be thrown.
+        """
+        updateRTMPVideo(id: Int!, name: String, rtmpUrl: String): Video
         """
         Delete a video from the database. Also deletes any video-links to productions using this Video.
         Returns true on success, false otherwise.
@@ -277,7 +292,7 @@ const typeDefs = gql`
     type Video {
         id: ID!
         name: String!
-        videoType: Int!
+        videoType: VideoType!
         data: JSON!
     }
 

--- a/schema.js
+++ b/schema.js
@@ -156,22 +156,22 @@ const typeDefs = gql`
         """
         Create a new embed-based video in the database. Requires a url that begins with "http://" or "https://".
         """
-        createEmbedVideo(name: String!, url: String!): Video
+        createEmbedVideo(name: String!, url: String!): EmbedVideo
         """
         Create a new RTMP-based video in the database. Requires a url that begins with "rtmp://". RTMP requires
         Flash Player, and as such, this type of video should soon be deprecated.
         """
-        createRTMPVideo(name: String!, rtmpUrl: String!): Video
+        createRTMPVideo(name: String!, rtmpUrl: String!): RTMPVideo
         """
         Update an embed-based video in the database.
         If the video with the provided ID is not an embed video, an error will be thrown.
         """
-        updateEmbedVideo(id: Int!, name: String, url: String): Video
+        updateEmbedVideo(id: Int!, name: String, url: String): EmbedVideo
         """
         Update an RTMP-based video in the database. 
         If the video with the provided ID is not an RTMP video, an error will be thrown.
         """
-        updateRTMPVideo(id: Int!, name: String, rtmpUrl: String): Video
+        updateRTMPVideo(id: Int!, name: String, rtmpUrl: String): RTMPVideo
         """
         Delete a video from the database. Also deletes any video-links to productions using this Video.
         Returns true on success, false otherwise.
@@ -286,14 +286,32 @@ const typeDefs = gql`
 
     """
     Videos are a type of media content which contain the metadata for a given video file on the site.
-    Different types of videos can have different attributes, so a loosely-defined schema exists in this type's
-    "data" field.
+    Different types of videos can have different attributes, as defined by types that inherit this.
     """
-    type Video {
+    interface Video {
         id: ID!
         name: String!
         videoType: VideoType!
-        data: JSON!
+    }
+
+    """
+    Embed-based video. Embedded videos are things such as YouTube videos which go in an iframe on the client.
+    """
+    type EmbedVideo implements Video {
+        id: ID!
+        name: String!
+        videoType: VideoType!
+        url: String!
+    }
+    
+    """
+    RTMP-based video. RTMP-based videos require an Adobe Flash video player, and as such should be deprecated soon.
+    """
+    type RTMPVideo implements Video {
+        id: ID!
+        name: String!
+        videoType: VideoType!
+        url: String!
     }
 
     """


### PR DESCRIPTION
There's two aspects to this:
1. `Video` objects in Javascript
2. `Video` types in GraphQL

In this PR, 1. mostly remains the same, while 2. is improved to be much more strict. GraphQL now considers different video types as different Types that implement the supertype `Video`. Some methods still return the `Video` supertype. If you use these in client queries and want to access subtype properties, you have to use (inline) fragmenting:
https://graphql.org/learn/queries/#inline-fragments

 In terms of what has changed internally in the Javascript, there are now different creator methods (`createEmbedVideo` and `createRTMPVideo`) however all metadata is still stored in the `data` property. There are not separate classes for different video types (mostly because this would likely cause more trouble than it solves with Javascripts current class system). Before being shipped to the client, `Video#unpackForClient()` should be called to unpack data in the `data` property to the root of the `Video` object.

This PR also:
* Removes the `MPEG_DASH` video type. It hasn't been finalized that we're using MPEG DASH moving forward.
* Adds an enum `VideoTypes` to GraphQL and updates VideoType values elsewhere to be strings instead of integers.