### PR TITLE
Add search context to itemCount values in GraphQL

### DIFF
--- a/classes/Category.js
+++ b/classes/Category.js
@@ -140,11 +140,28 @@ function CategoryModelFactory(SEEKER, SUPER_ACCESS) {
 
         /**
          * Get the total number of categories in the database.
+         * @param searchCtx {String} Search context provided by the user. This context can be passed to a parser, which
+         * will provide limitations on the search query. searchCtx defaults to an empty string.
          * @returns {Promise<number>} The total number of categories in the database.
          * @throws PostgreSQL error
          */
-        static async getCategoryCount() {
-            const response = await pool.query('SELECT COUNT(id) FROM categories');
+        static async getCategoryCount(searchCtx) {const search = new Search(searchCtx || '')
+
+            if (search.count() > 10) {
+                throw new Error('Please use less than 10 search terms.')
+            }
+            const searchClause = search.buildSQL([{
+                name: 'id',
+                type: Number
+            },{
+                name: 'name',
+                type: String
+            }
+            ])
+
+            const paramArray = search.getParamArray()
+            const response = await pool.query('SELECT COUNT(id) FROM (SELECT id FROM categories ' + searchClause + ') AS derived;',
+                paramArray);
             return response.rows[0].count;
         }
 

--- a/classes/Person.js
+++ b/classes/Person.js
@@ -248,11 +248,39 @@ function PersonModelFactory(SEEKER, SUPER_ACCESS) {
 
         /**
          * Get the total number of people in the database.
+         * @param searchCtx {String} Search context provided by the user. This context can be passed to a parser, which
+         * will provide limitations on the search query. searchCtx defaults to an empty string.
          * @returns {Promise<number>} The total number of people in the database.
          * @throws PostgreSQL error
          */
-        static async getPeopleCount() {
-            const response = await pool.query('SELECT COUNT(id) FROM people;');
+        static async getPeopleCount(searchCtx) {
+            const search = new Search(searchCtx || '')
+
+            if (search.count() > 10) {
+                throw new Error('Please use less than 10 search terms.')
+            }
+            const searchClause = search.buildSQL([{
+                name: 'id',
+                type: Number
+            },{
+                name: 'first_name',
+                type: String
+            },{
+                name: 'preferred_name',
+                type: String
+            },{
+                name: 'last_name',
+                type: String
+            },{
+                name: 'class_year',
+                type: Number
+            }
+            ])
+
+            const paramArray = search.getParamArray()
+
+            const response = await pool.query('SELECT COUNT(id) FROM (SELECT id FROM people ' + searchClause + ') AS derived;',
+                paramArray);
             return response.rows[0].count;
         }
 

--- a/classes/Video.js
+++ b/classes/Video.js
@@ -85,11 +85,29 @@ function VideoModelFactory(SEEKER, SUPER_ACCESS) {
 
         /**
          * Get the total number of videos in the database.
+         * @param searchCtx {String} Search context provided by the user. This context can be passed to a parser, which
+         * will provide limitations on the search query. searchCtx defaults to an empty string.
          * @returns {Promise<number>} The total number of videos in the database.
          * @throws PostgreSQL error
          */
-        static async getVideoCount() {
-            const response = await pool.query('SELECT COUNT(id) FROM videos');
+        static async getVideoCount(searchCtx) {
+            const search = new Search(searchCtx || '')
+
+            if (search.count() > 10) {
+                throw new Error('Please use less than 10 search terms.')
+            }
+            const searchClause = search.buildSQL([{
+                name: 'id',
+                type: Number
+            },{
+                name: 'name',
+                type: String
+            }
+            ])
+
+            const paramArray = search.getParamArray()
+            const response = await pool.query('SELECT COUNT(id) FROM (SELECT id FROM videos ' + searchClause + ') AS derived;',
+                paramArray);
             return response.rows[0].count;
         }
 

--- a/resolvers.js
+++ b/resolvers.js
@@ -61,25 +61,25 @@ const resolvers = {
         },
 
         userCount: async (obj, args, ctx) => {
-            return ctx.model.User.getUserCount();
+            return ctx.model.User.getUserCount(args.searchCtx);
         },
         peopleCount: async (obj, args, ctx) => {
-            return ctx.model.Person.getPeopleCount();
+            return ctx.model.Person.getPeopleCount(args.searchCtx);
         },
         memberCount: async (obj, args, ctx) => {
             return ctx.model.Person.getMemberCount();
         },
         imageCount: async (obj, args, ctx) => {
-            return ctx.model.Image.getImageCount();
+            return ctx.model.Image.getImageCount(args.searchCtx);
         },
         videoCount: async (obj, args, ctx) => {
-            return ctx.model.Video.getVideoCount();
+            return ctx.model.Video.getVideoCount(args.searchCtx);
         },
         productionCount: async (obj, args, ctx) => {
-            return ctx.model.Production.getProductionCount();
+            return ctx.model.Production.getProductionCount(args.searchCtx);
         },
         categoryCount: async (obj, args, ctx) => {
-            return ctx.model.Category.getCategoryCount();
+            return ctx.model.Category.getCategoryCount(args.searchCtx);
         }
     },
     User: {

--- a/schema.js
+++ b/schema.js
@@ -79,33 +79,33 @@ const typeDefs = gql`
         getCategory(id: Int!): Category
         
         """
-        The total number of Users in the database.
+        The total number of Users in the database. Optionally provide a search context.
         """
-        userCount: Int!
+        userCount(searchCtx: String): Int!
         """
         The total number of Persons in the database which have an active Role at the given moment.
         """
         memberCount: Int!
         """
-        The total number of Persons in the database.
+        The total number of Persons in the database. Optionally provide a search context.
         """
-        peopleCount: Int!
+        peopleCount(searchCtx: String): Int!
         """
-        The total number of Images in the database.
+        The total number of Images in the database. Optionally provide a search context.
         """
-        imageCount: Int!
+        imageCount(searchCtx: String): Int!
         """
-        The total number of Videos in the database.
+        The total number of Videos in the database. Optionally provide a search context.
         """
-        videoCount: Int!
+        videoCount(searchCtx: String): Int!
         """
-        The total number of Productions in the database.
+        The total number of Productions in the database. Optionally provide a search context.
         """
-        productionCount: Int!
+        productionCount(searchCtx: String): Int!
         """
-        The total number of Categories in the database.
+        The total number of Categories in the database. Optionally provide a search context.
         """
-        categoryCount: Int!
+        categoryCount(searchCtx: String): Int!
     }
     
     type Mutation {


### PR DESCRIPTION
Added ability to get a count of the number of items which match a specified search context, as opposed to the total count.