### PR TITLE
Add credits fetching in GraphQL Production type

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -958,6 +958,7 @@ export type Production = {
   category?: Maybe<Category>;
   closetLocation?: Maybe<Scalars['String']>;
   closetTime?: Maybe<Scalars['DateTime']>;
+  credits?: Maybe<Array<Credit>>;
   description?: Maybe<Scalars['String']>;
   discordChannel?: Maybe<Scalars['String']>;
   discordServer?: Maybe<Scalars['String']>;
@@ -2214,6 +2215,7 @@ export type ProductionResolvers<ContextType = any, ParentType extends ResolversP
   category?: Resolver<Maybe<ResolversTypes['Category']>, ParentType, ContextType>;
   closetLocation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   closetTime?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  credits?: Resolver<Maybe<Array<ResolversTypes['Credit']>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   discordChannel?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   discordServer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -432,6 +432,7 @@ async function createGraphQLServer(): Promise<
                     "rsvps",
                     "tags",
                     "videos",
+                    "credits",
                     "category",
                     "thumbnail",
                 ],

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1170,6 +1170,7 @@ type Production {
     rsvps: [ProductionRSVP!] @Auth(action: read, subject: Production ,field: "rsvps") @Auth(action: read, subject: ProductionRSVP)
     tags: [ProductionTag!] @Auth(action: read, subject: Production, field: "tags") @Auth(action: read, subject: ProductionTag)
     videos: [ProductionVideo!] @Auth(action: read, subject: Production, field: "videos") @Auth(action: read, subject: ProductionVideo)
+    credits: [Credit!] @Auth(action: read, subject: Production, field: "credits") @Auth(action: read, subject: Credit)
 }
 
 input ProductionCreateInput {


### PR DESCRIPTION
This fixes issue #47 by adding the ability to query "credits" under a Production in GraphQL.