### PR TITLE
Update @Rule decorator, remove HTTP support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,7 +39,7 @@ import { UserPermissionModule } from "./types/user_permission/user_permission.mo
 import { VideoModule } from "./types/video/video.module";
 import { VoteModule } from "./types/vote/vote.module";
 import { VoteResponseModule } from "./types/vote_response/vote_response.module";
-import { GraphQLCustomRuleDirective, GraphQLRuleDirective, RuleDirective } from "./casl/rule.directive";
+import { GraphQLRuleDirective, RuleDirective } from "./casl/rule.directive";
 import { StreamModule } from "./types/stream/stream.module";
 import { ConfigModule } from "@nestjs/config";
 import * as Joi from "joi";
@@ -51,8 +51,7 @@ import * as Joi from "joi";
             imports: [CaslModule],
             inject: [RuleDirective],
             useFactory: async (ruleDirective: RuleDirective) => ({
-                transformSchema: (schema) =>
-                    ruleDirective.createCustom(ruleDirective.createBasic(schema, "rule"), "custom_rule"),
+                transformSchema: (schema) => ruleDirective.createBasic(schema, "rule"),
                 autoSchemaFile: path.join(process.cwd(), "generated/schema.gql"),
                 sortSchema: true,
                 playground: {
@@ -61,7 +60,7 @@ import * as Joi from "joi";
                     }
                 },
                 buildSchemaOptions: {
-                    directives: [GraphQLRuleDirective, GraphQLCustomRuleDirective]
+                    directives: [GraphQLRuleDirective]
                 }
             })
         }),

--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -1,10 +1,11 @@
-import { Args, Context, Directive, Mutation, Resolver } from "@nestjs/graphql";
+import { Args, Context, Mutation, Resolver } from "@nestjs/graphql";
 import { User } from "../types/user/user.entity";
 import { UseFilters, UseGuards } from "@nestjs/common";
 import { LocalAuthGuard } from "./LocalAuthGuard.guard";
 import { CurrentUser } from "./current-user.decarator";
 import { CaslAbilityFactory } from "../casl/casl-ability.factory";
 import { OAuthExceptionFilter } from "./OAuthException.filter";
+import { Rule, RuleType } from "../casl/rule.decorator";
 
 @Resolver(() => User)
 export class AuthResolver {
@@ -13,7 +14,7 @@ export class AuthResolver {
     @UseGuards(LocalAuthGuard)
     @UseFilters(OAuthExceptionFilter)
     @Mutation(() => User)
-    @Directive('@rule(ruleType: ReadOne, subject: User, options: { name: "Local login", defer: true })')
+    @Rule(RuleType.ReadOne, User, { name: "Local login", defer: true })
     async loginLocal(
         @Args("username") username: string,
         @Args("password") password: string,

--- a/src/casl/casl.helper.ts
+++ b/src/casl/casl.helper.ts
@@ -1,12 +1,10 @@
 import { ExecutionContext, Injectable, InternalServerErrorException, Logger } from "@nestjs/common";
-import { RuleDef, RuleFn, RuleType } from "./rule.decorator";
+import { RuleDef, RuleHandler, ruleHandlers, RuleType } from "./rule.decorator";
 import { AbilityAction, AbilitySubjects, GlimpseAbility } from "./casl-ability.factory";
-import { subject } from "@casl/ability";
 import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 import { GraphQLList, GraphQLResolveInfo, GraphQLType } from "graphql/type";
 import { EnumValueNode, IntValueNode, Kind, SelectionNode, visit } from "graphql/language";
 import PaginationInput from "../gql/pagination.input";
-import { map, Observable, of, tap } from "rxjs";
 import { Request } from "express";
 import { GraphQLResolverArgs } from "../gql/graphql-resolver-args.class";
 import { GraphQLNonNull } from "graphql";
@@ -34,21 +32,16 @@ export class CaslHelper {
         "not",
         "mode"
     ] as const;
+
+    public readonly handlerToRuleTypeMap = new Map<RuleHandler, RuleType>();
+
     private readonly logger: Logger = new Logger("CaslHelper");
 
-    /**
-     * Map of RuleType to the corresponding handler function.
-     * @private
-     */
-    public readonly handlers: Map<RuleType, RuleFn> = new Map([
-        [RuleType.ReadOne, this.handleReadOneRule.bind(this)],
-        [RuleType.ReadMany, this.handleReadManyRule.bind(this)],
-        [RuleType.Count, this.handleCountRule.bind(this)],
-        [RuleType.Custom, this.handleCustomRule.bind(this)],
-        [RuleType.Create, this.handleCreateRule.bind(this)],
-        [RuleType.Update, this.handleUpdateRule.bind(this)],
-        [RuleType.Delete, this.handleDeleteRule.bind(this)]
-    ]);
+    constructor() {
+        for (const ruleType of Object.values(RuleType)) {
+            this.handlerToRuleTypeMap.set(ruleHandlers.get(ruleType), ruleType);
+        }
+    }
 
     /**
      * Format a Rule's name into a string that can be used to identify it in logs. If a name was not provided in the
@@ -59,18 +52,30 @@ export class CaslHelper {
      *  returned.
      */
     public formatRuleName(rule: RuleDef): string {
-        const setName = rule[2]?.name;
+        // FIXME
+
+        const setName = rule.options?.name;
         // If a name wasn't provided in the rule config, the name can be inferred from the rule's type and subject.
-        if (setName === undefined && rule[0] !== RuleType.Custom) {
-            if (typeof rule[1] === "string") {
-                return `Rule "${rule[0]} ${rule[1]}"`;
-            } else if (typeof rule[1] === "function") {
-                return `Rule "${rule[0]} ${rule[1].modelName || rule[1].name || rule[1]}"`;
+        if (setName === undefined) {
+            const ruleType = this.handlerToRuleTypeMap.get(rule.fn);
+            const ruleTypeStr = ruleType ?? "<Custom Rule>";
+
+            let subj;
+            if (typeof rule.subject === "string") {
+                subj = rule.subject;
+            } else if (typeof rule.subject === "function") {
+                subj = rule.subject.modelName;
+            } else if (rule.subject === null) {
+                subj = "<null subject>";
+            } else {
+                subj = rule.subject.constructor.name;
             }
+
+            return `Rule "${ruleTypeStr} ${subj}"`;
         }
         // If a name was explicitly set but is null or an empty string (or can't be inferred), use "Unnamed rule".
         //  Otherwise, return the name.
-        return setName ? `Rule "${setName}"` : "Unnamed rule";
+        return setName ? `Rule "${setName}"` : "Unknown rule";
     }
 
     /**
@@ -136,23 +141,19 @@ export class CaslHelper {
      * @throws Error if the rule is of type {@link RuleType.Custom}.
      * @private
      */
-    private getReqAndSubject(
+    public getReqAndSubject(
         context: ExecutionContext | GraphQLResolverArgs,
         rule: RuleDef
     ): {
         req: Request;
         subjectStr: Extract<AbilitySubjects, string>;
     } {
-        if (rule[0] === RuleType.Custom) {
-            throw new Error(`Cannot test rule of type "${rule[0]}" with non-custom rule handler.`);
-        }
-
         const req = this.getRequest(context);
         if (!req.permissions) {
             throw new Error("User permissions not initialized.");
         }
 
-        const subjectStr = this.getSubjectAsString(rule[1]);
+        const subjectStr = this.getSubjectAsString(rule.subject);
 
         return { req, subjectStr };
     }
@@ -623,705 +624,5 @@ export class CaslHelper {
             );
             throw new Error("Unknown subject type");
         }
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.Custom}. This function just ensures that the
-     *  rule's type is {@link RuleType.Custom} and then calls the rule's custom definition.
-     *
-     *  This function is almost completely unnecessary. Since this function has the same definition as the rule's custom
-     *  function itself, we could technically just call the rule's custom function directly. However, the {@link Rule}
-     *  decorator accepts classes as the subject type in non-custom rules, and there isn't a <i>great</i> way to
-     *  distinguish between a function and class at runtime. With some refactoring, this could be made to work, but
-     *  isn't a priority as of writing this.
-     *
-     * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
-     *  applied to.
-     * @param context NestJS execution context.
-     * @param rule {@link RuleDef} to test. If rule type is not {@link RuleType.Custom}, or if the rule definition is
-     *  not a {@link RuleFn}, an error will be thrown.
-     * @param handler The handler that calls the request method/resolver, or the next interceptor in line if applicable.
-     *  This is passed to the rule function, allowing the rule function to call the resolver at the appropriate time.
-     * @returns The returned value from the rule function. Typically, this will be the value returned from the
-     *  resolver/handler, but the rule function is allowed to mutate that value, or return a completely different value.
-     *  Whatever is returned should be treated as the final value returned from the resolver/handler.
-     * @throws Error if the rule type is not {@link RuleType.Custom}.
-     */
-    public handleCustomRule<T = any>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T>
-    ): Observable<T> {
-        if (rule[0] !== RuleType.Custom) {
-            throw new Error(`Cannot test rule of type "${rule[0]}" with testCustomRule.`);
-        }
-
-        return rule[1](context, rule, handler);
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.ReadOne}. This function ensures that the user has
-     *  permission to read a single resource of the given type, and intercepts the returned value from the
-     *  resolver/handler that it is applied to, to make sure the user has permission to read that specific value.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read the resource, then this method sets {@link Express.Request#passed}
-     *  to false on the context's request object and returns null, potentially before calling the handler. From there,
-     *  the {@link CaslInterceptor} will see that {@link Request#passed} is false and throw an error.
-     *  {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule is applied to,
-     *  which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument.
-     *
-     * @todo Support toggling strict mode?
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
-     *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
-     *  no longer be required.
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
-     *  mutate the return value from the next handler.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleReadOneRule<T extends Exclude<AbilitySubjects, string>>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T | null>
-    ): Observable<T | null> {
-        this.logger.debug("Handling ReadOne rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!rule[2]?.defer && !req.permissions.can(AbilityAction.Read, subjectStr)) {
-            this.logger.verbose("Failed basic ReadOne rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        const fields: Set<string> = new Set();
-        // Field-based tests can only be done pre-resolver for GraphQL requests, since the request includes the
-        //  fields to be returned. Non-GraphQL requests don't include this, as all fields are returned.
-        if (context instanceof GraphQLResolverArgs || context.getType<GqlContextType>() === "graphql") {
-            // getSelectedFields includes type, but we only want the field name.
-            this.getSelectedFields(context).forEach((v) => fields.add(v.split(".", 2)[1]));
-
-            // Remove any specifically excluded fields from the list of fields.
-            if (rule[2]?.excludeFields) {
-                rule[2].excludeFields.forEach((v) => fields.delete(v));
-            }
-
-            // Test the ability against each requested field
-            for (const field of fields) {
-                if (!rule[2]?.defer && !req.permissions.can(AbilityAction.Read, subjectStr, field)) {
-                    this.logger.verbose(`Failed field-based ReadOne rule test for field "${field}".`);
-                    req.passed = false;
-                    return of(null);
-                }
-            }
-        }
-
-        // Call next rule, or resolver/handler if no more rules.
-        return handler().pipe(
-            map((value) => {
-                // Handler already marked the request as failed for some permission error.
-                if (req.passed === false) {
-                    this.logger.verbose("Failed ReadOne rule test. Handler already marked as failed.");
-                    return null;
-                }
-
-                // If the value is nullish, there's no value to check, so just return null.
-                if (value === null || value === undefined) {
-                    req.passed = true;
-                    return null;
-                }
-
-                // Repeat previous tests with the value as the subject.
-
-                const subjectObj = subject(subjectStr, value);
-
-                if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
-                    this.logger.verbose("Failed basic ReadOne rule test with value as subject.");
-                    req.passed = false;
-                    return null;
-                }
-
-                // In GQL contexts, fields were determined pre-resolver. In other contexts, we can only determine them
-                //  post-resolver, which is done here.
-                if (!(context instanceof GraphQLResolverArgs) && context.getType<GqlContextType>() !== "graphql") {
-                    Object.keys(value).forEach((v) => fields.add(v));
-
-                    // Remove any specifically excluded fields from the list of fields.
-                    if (rule[2]?.excludeFields) {
-                        rule[2].excludeFields.forEach((v) => fields.delete(v));
-                    }
-                }
-
-                // Test the ability against each requested field with subject value.
-                for (const field of fields) {
-                    if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
-                        this.logger.verbose(
-                            `Failed field-based ReadOne rule test for field "${field}" with value as subject.`
-                        );
-                        req.passed = false;
-                        return null;
-                    }
-                }
-
-                req.passed = true;
-                return value;
-            })
-        );
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.ReadMany}. This function ensures that the user
-     *  has permission to read an array of resources of the given type, and intercepts the returned values from the
-     *  resolver/handler that it is applied to, to make sure the user has permission to read all the returned values.
-     *
-     *  In addition to traditional subject/field permission checks, ReadMany rules also allow for the use of sorting,
-     *  filtering, and pagination. These permissions are handled as such:
-     *
-     *  - <b>Sorting:</b> The user must have {@link AbilityAction.Sort} permission on the field being sorted by. The
-     *    user's ability to read the field(s) being sorted is not currently taken into account. As such, it is possible
-     *    for a user to infer some information about fields which they cannot read as long as they have permission to
-     *    sort by them. With combinations of subsequent sorts, the user may be able to decipher the value completely.
-     *  - <b>Filtering:</b> The user must have {@link AbilityAction.Filter} permission on the field being filtered by.
-     *    The user's ability to read the individual field(s) being filtered is not currently taken into account. As
-     *    such, it is possible for a user to infer some information about fields which they cannot read as long as they
-     *    have permission to filter by them. With complex and combinations of filters, the user may be able to decipher
-     *    the value completely.
-     *  - <b>Pagination:</b> Generally, there are no permission checks against permission necessary. However, if the
-     *    user is using cursor-based pagination, they must have permission to sort by the "ID" field. This is because
-     *    cursor-based pagination requires sorting by some field by its very nature, and the "ID" field is the only
-     *    field which Glimpse currently allows to be used for this. For skip-based pagination, there are no permission
-     *    checks.
-     *
-     *  Currently, sorting and filtering permissions cannot have conditions applied to them. It is expected that any
-     *  sorting or filtering permissions that the user has, do not have conditions applied. If they do, the conditions
-     *  will currently be ignored and the user will be able to sort or filter by the field regardless of the conditions.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read the resources, then this method sets {@link Express.Request#passed}
-     *  to false on the context's request object and returns null, potentially before calling the handler. From there,
-     *  the {@link CaslInterceptor} will see that {@link Request#passed} is false and throw an error.
-     *  {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule is applied to,
-     *  which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument. Namely, strict mode currently applies exclusively to this rule type, allowing you to control what
-     *  happens when the user doesn't have permission to read a field only on a subset of values of the requested type.
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @typeParam T - The type of the array of values expected to be returned by the resolver/handler which this rule
-     *  is being applied to. E.g., if the resolver returns an array of {@link User| Users}, T would be {@link User}.
-     *  Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may no longer be
-     *  required.
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. If the rule's strict mode is
-     *  enabled, then this will return null if the user doesn't have permission to read one or more of the fields on
-     *  any object within the array returned by handler. However, if the rule's strict mode is disabled, then those
-     *  fields will be set to null on the relevant objects. Note that if the user doesn't have permission to read the
-     *  field on <i>any</i> object of the given type, the same behavior as strict mode will occur. That is, null will
-     *  be returned and {@link Express.Request#passed} will be set to false. It is only when the user has permission to
-     *  read the field on some objects of the given type that the strict mode behavior will differ.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleReadManyRule<T extends Exclude<AbilitySubjects, string>>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T[] | null>
-    ): Observable<T[] | null> {
-        this.logger.debug("Handling ReadMany rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!req.permissions.can(AbilityAction.Read, subjectStr)) {
-            this.logger.verbose("Failed basic ReadMany rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        // Make sure user has permission to sort by the fields which they are sorting by.
-        if (!this.canSortByFields(context, req, subjectStr, rule[2]?.orderInputName ?? "order")) {
-            this.logger.verbose(
-                "User doesn't have permission to sort by one or more of their supplied sorting arguments."
-            );
-            req.passed = false;
-            return of(null);
-        }
-
-        // Make sure user has permission to filter by the fields which they are filtering by.
-        if (!this.canFilterByFields(context, req, subjectStr, rule[2]?.filterInputName ?? "filter")) {
-            this.logger.verbose("User doesn't have permission to filter by one or more of their supplied filters.");
-            req.passed = false;
-            return of(null);
-        }
-
-        if (!this.canPaginate(context, req.permissions, subjectStr, rule[2]?.paginationInputName ?? "pagination")) {
-            this.logger.verbose(
-                `User supplied cursor-based pagination argument(s) but doesn't have permission to sort by ID on the 
-                subject "${subjectStr}".`
-            );
-            req.passed = false;
-            return of(null);
-        }
-
-        const fields: Set<string> = new Set();
-        // Field-based tests can only be done pre-resolver for GraphQL requests, since the request includes the
-        //  fields to be returned. Non-GraphQL requests don't include this, as all fields are returned.
-        if (context instanceof GraphQLResolverArgs || context.getType<GqlContextType>() === "graphql") {
-            // getSelectedFields includes type, but we only want the field name.
-            this.getSelectedFields(context).forEach((v) => fields.add(v.split(".", 2)[1]));
-
-            // Remove any specifically excluded fields from the list of fields.
-            if (rule[2]?.excludeFields) {
-                rule[2].excludeFields.forEach((v) => fields.delete(v));
-            }
-
-            // Test the ability against each requested field
-            for (const field of fields) {
-                if (!req.permissions.can(AbilityAction.Read, subjectStr, field)) {
-                    this.logger.verbose(`Failed field-based ReadMany rule test for field "${field}".`);
-                    req.passed = false;
-                    return of(null);
-                }
-            }
-        }
-
-        // Call next rule, or resolver/handler if no more rules.
-        return handler().pipe(
-            map((values) => {
-                // Handler already marked the request as failed for some permission error.
-                if (req.passed === false) {
-                    this.logger.verbose("Failed ReadMany rule test. Handler already marked as failed.");
-                    return null;
-                }
-
-                // If the value is nullish, there's no value to check, so just return null.
-                if (values === null || values === undefined) {
-                    req.passed = true;
-                    return null;
-                }
-
-                // Repeat previous tests with the values as the subject.
-
-                for (const value of values) {
-                    const subjectObj = subject(subjectStr, value);
-                    if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
-                        this.logger.verbose("Failed basic ReadMany rule test on one or more values.");
-                        req.passed = false;
-                        return null;
-                    }
-
-                    // In GQL contexts, fields were determined pre-resolver. In other contexts, we can only determine them
-                    //  post-resolver, which is done here.
-                    if (!(context instanceof GraphQLResolverArgs) && context.getType<GqlContextType>() !== "graphql") {
-                        Object.keys(value).forEach((v) => fields.add(v));
-
-                        // Remove any specifically excluded fields from the list of fields.
-                        if (rule[2]?.excludeFields) {
-                            rule[2].excludeFields.forEach((v) => fields.delete(v));
-                        }
-                    }
-
-                    // Test the ability against each requested field with subject value.
-                    for (const field of fields) {
-                        if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
-                            // Strict mode will cause the entire request to fail if any field fails. Otherwise, the field
-                            //  will be set to null. The user won't necessarily know (as of now) whether the field is
-                            //  actually null, or they just can't read it.
-                            if (rule[2]?.strict ?? false) {
-                                this.logger.verbose(
-                                    `Failed field-based ReadMany rule test for field "${field}" on one or more values.`
-                                );
-                                req.passed = false;
-                                return null;
-                            } else {
-                                this.logger.verbose(
-                                    `Failed field-based ReadMany rule test for field "${field}" on one value. More may come...`
-                                );
-                                value[field] = null;
-                            }
-                        }
-                    }
-                }
-
-                req.passed = true;
-                return values;
-            })
-        );
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.Count}. This function ensures that the user
-     *  has permission to read at least one resource of the given type, as count resolvers should only be returning the
-     *  count of resources the user has permission to read (as well as match their supplied filter).
-     *
-     *  The user must have {@link AbilityAction.Filter} permission on the field being filtered by. The user's
-     *  ability to read the individual field(s) being filtered is not currently taken into account. As such, it is
-     *  possible for a user to infer some information about fields which they cannot read as long as they have
-     *  permission to filter by them. With complex and combinations of filters, the user may be able to decipher the
-     *  value completely.
-     *
-     *  Currently, filtering permissions cannot have conditions applied to them. It is expected that any sorting or
-     *  filtering permissions that the user has, do not have conditions applied. If they do, the conditions will
-     *  currently be ignored and the user will be able to sort or filter by the field regardless of the conditions.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read the resource type, then this method sets
-     *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
-     *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
-     *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
-     *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument.
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
-     *  mutate the return value from the next handler.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleCountRule(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<number | null>
-    ): Observable<number | null> {
-        this.logger.debug("Handling Count rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!req.permissions.can(AbilityAction.Read, subjectStr)) {
-            this.logger.verbose("Failed basic Count rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        // Make sure user has permission to filter by the fields which they are filtering by.
-        if (!this.canFilterByFields(context, req, subjectStr, rule[2]?.filterInputName ?? "filter")) {
-            this.logger.verbose("User doesn't have permission to filter by one or more of their supplied filters.");
-            req.passed = false;
-            return of(null);
-        }
-
-        // No permission checks need to be applied to the returned value (it's just a number), so return it.
-        return handler().pipe(tap(() => (req.passed = true)));
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.Create}. This function ensures that the user has
-     *  permission to create a resource of the given type, and intercepts the returned value from the resolver/handler
-     *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
-     *  wrapping this method in the {@link this#readOneRuleHandler} method.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read or create the resource, then this method sets
-     *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
-     *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
-     *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
-     *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument.
-     *
-     * @todo Support toggling strict mode?
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
-     *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
-     *  no longer be required.
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
-     *  mutate the return value from the next handler.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleCreateRule<T extends Exclude<AbilitySubjects, string>>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T | null>
-    ): Observable<T | null> {
-        this.logger.debug("Handling Create rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!req.permissions.can(AbilityAction.Create, subjectStr)) {
-            this.logger.verbose("Failed basic Create rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        const inputFields = this.getInputFields(context, rule[2]?.inputName ?? "input");
-
-        // Make sure user can create an object with the fields they've supplied.
-        for (const field of inputFields) {
-            if (!req.permissions.can(AbilityAction.Create, subjectStr, field)) {
-                this.logger.verbose(`Failed Create rule test for field ${field}.`);
-                req.passed = false;
-                return of(null);
-            }
-        }
-
-        // Make sure user has permission to read the fields they're trying to read from their creation. If it's
-        //  determined after the creation that the user doesn't have permission to read it, the creation will be rolled
-        //  back thanks to PrismaInterceptor.
-        return this.handleReadOneRule(context, rule, () => {
-            return handler().pipe(
-                map((newValue) => {
-                    // Handler already marked the request as failed for some permission error.
-                    if (req.passed === false) {
-                        this.logger.verbose("Failed Create rule test. Handler already marked as failed.");
-                        return null;
-                    }
-
-                    const subjectObj = subject(subjectStr, newValue);
-
-                    // Check that the user has permission to create an object like this one. If not, prisma tx will roll back.
-                    for (const field of Object.keys(newValue)) {
-                        if (!req.permissions.can(AbilityAction.Create, subjectObj, field)) {
-                            this.logger.verbose(`Failed Create rule test for field ${field} with value.`);
-                            req.passed = false;
-                            return null;
-                        }
-                    }
-
-                    req.passed = true;
-                    return newValue;
-                })
-            );
-        });
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.Update}. This function ensures that the user has
-     *  permission to update a resource of the given type, and intercepts the returned value from the resolver/handler
-     *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
-     *  wrapping this method in the {@link this#readOneRuleHandler} method.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read or update the resource, then this method sets
-     *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
-     *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
-     *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
-     *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument.
-     *
-     * @todo Support toggling strict mode?
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
-     *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
-     *  no longer be required.
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
-     *  mutate the return value from the next handler.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleUpdateRule<T extends Exclude<AbilitySubjects, string>>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T | null>
-    ): Observable<T | null> {
-        this.logger.debug("Handling Update rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!req.permissions.can(AbilityAction.Update, subjectStr)) {
-            this.logger.verbose("Failed basic Update rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        const inputFields = this.getInputFields(context, rule[2]?.inputName ?? "input");
-
-        // Make sure user can update an object with the fields they've supplied.
-        for (const field of inputFields) {
-            if (!req.permissions.can(AbilityAction.Update, subjectStr, field)) {
-                this.logger.verbose(`Failed Update rule test for field ${field}.`);
-                req.passed = false;
-                return of(null);
-            }
-        }
-
-        // FIXME currently there is no way to check within the interceptor if the user has permission to update the
-        //  object to update before it's been updated. This check needs to be done in the resolver. This can be solved
-        //  in a future refactor. Unlike the delete rule, this is a required check.
-
-        return handler()
-            .pipe(
-                map((newValue) => {
-                    // Handler already marked the request as failed for some permission error.
-                    if (req.passed === false) {
-                        this.logger.verbose("Failed Update rule test. Handler already marked as failed.");
-                        return null;
-                    }
-
-                    const subjectObj = subject(subjectStr, newValue);
-
-                    // Check that the user has permission to update TO an object like this one. If not, prisma tx will roll
-                    //  back.
-                    for (const field of inputFields) {
-                        if (!req.permissions.can(AbilityAction.Update, subjectObj, field)) {
-                            this.logger.verbose(`Failed Update rule test for field ${field} with value.`);
-                            req.passed = false;
-                            return null;
-                        }
-                    }
-
-                    req.passed = true;
-                    return newValue;
-                })
-            )
-            .pipe((v) => {
-                // Make sure user has permission to read the fields they're trying to read after the update. Update will
-                //  be rolled back if not.
-                return this.handleReadOneRule(context, rule, () => v);
-            });
-    }
-
-    /**
-     * Handle a {@link Rule} definition with rule type {@link RuleType.Delete}. This function ensures that the user has
-     *  permission to delete a resource of the given type, and intercepts the returned value from the resolver/handler
-     *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
-     *  wrapping this method in the {@link this#readOneRuleHandler} method.
-     *
-     *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
-     *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
-     *  value.
-     *
-     *  If the user does not have permission to read or delete the resource, then this method sets
-     *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
-     *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
-     *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
-     *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
-     *
-     *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
-     *  argument.
-     *
-     * @todo Support toggling strict mode?
-     *
-     * @see {@link RuleOptions}
-     * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
-     *
-     * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
-     *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
-     *  no longer be required.
-     * @param context - NestJS execution context.
-     * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
-     * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
-     *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
-     *  return value.
-     * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
-     *  mutate the return value from the next handler.
-     * @throws Error if the rule type is {@link RuleType.Custom}.
-     * @throws Error if the current user's permissions are not initialized.
-     */
-    public handleDeleteRule<T extends Exclude<AbilitySubjects, string>>(
-        context: ExecutionContext | GraphQLResolverArgs,
-        rule: RuleDef,
-        handler: () => Observable<T | null>
-    ): Observable<T | null> {
-        this.logger.debug("Handling Delete rule.");
-        // Asserts that the rule is not a RuleType.Custom rule.
-        const { req, subjectStr } = this.getReqAndSubject(context, rule);
-
-        // Basic test with the provided action and subject.
-        if (!req.permissions.can(AbilityAction.Delete, subjectStr)) {
-            this.logger.verbose("Failed basic Delete rule test.");
-            req.passed = false;
-            return of(null);
-        }
-
-        // FIXME currently there is no way to check within the interceptor if the user has permission to delete the
-        //  object to delete before it's been deleted. This check needs to be done in the resolver. This can be solved
-        //  in a future refactor. Technically not required, but it could improve efficiency.
-
-        return handler()
-            .pipe(
-                map((newValue) => {
-                    // Handler already marked the request as failed for some permission error.
-                    if (req.passed === false) {
-                        this.logger.verbose("Failed Delete rule test. Handler already marked as failed.");
-                        return null;
-                    }
-
-                    // Check the user can actually delete the object. Note, the deletion has already happened within the
-                    //  transaction at this point. However, if the user doesn't have permission, it'll be rolled back.
-                    //  The resolver can also do this before executing the deletion query. See the FIX-ME above.
-                    const subjectObj = subject(subjectStr, newValue);
-                    if (!req.permissions.can(AbilityAction.Delete, subjectObj)) {
-                        this.logger.verbose("Failed Delete rule test with value.");
-                        req.passed = false;
-                        return null;
-                    }
-
-                    req.passed = true;
-                    return newValue;
-                })
-            )
-            .pipe((v) => {
-                // Make sure user has permission to read the fields they're trying to read after the deletion. Deletion will
-                //  be rolled back if not.
-                return this.handleReadOneRule(context, rule, () => v);
-            });
     }
 }

--- a/src/casl/casl.interceptor.ts
+++ b/src/casl/casl.interceptor.ts
@@ -1,42 +1,21 @@
-import { CallHandler, ExecutionContext, ForbiddenException, Injectable, Logger, NestInterceptor } from "@nestjs/common";
-import { Observable, tap } from "rxjs";
+import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
 import { CaslAbilityFactory } from "./casl-ability.factory";
-import { RuleDef, RULES_METADATA_KEY } from "./rule.decorator";
-import { Reflector } from "@nestjs/core";
 import { CaslHelper } from "./casl.helper";
 
 /**
- * Interceptor that retrieves the @Rule() decorators from controller handlers and resolvers, and makes sure that the
- *  currently logged-in user has permission to perform the attached action. If the user does not have permission, then
- *  a ForbiddenException is thrown. If the user does have permission, then the request continues on as normal. In some
- *  situations, the request's response may be altered by the interceptor to remove fields that the user is not allowed
- *  to see.
- *
- *  The @Rule() decorator should only be used for HTTP contexts. For GraphQL contexts, use the @rule GraphQL directive.
- *
- *  This interceptor also initializes {@link Request#permissions} if it's not already initialized. For some reason,
- *  this seems to not always work for GraphQL requests, so {@link CaslPlugin} does the same thing for GraphQL requests.
- *
- *  @see {@link RuleDirective} and {@link CaslPlugin} for GraphQL counterparts
- *  @see {@link Rule} for @Rule() decorator
- *  @see {@link CaslHelper} for implementations of rule checks
- *  @see {@link CaslAbilityFactory} for how permissions are generated
- *  @see {@link https://github.com/nestjs/graphql/issues/631}
+ * Interceptor that defines the user's {@link GlimpseAbility} on {@link Express.Request#permissions} if it's not already
+ *  defined. This is done with the help of {@link CaslAbilityFactory}.
  */
 @Injectable()
 export class CaslInterceptor implements NestInterceptor {
     private readonly logger: Logger = new Logger("CaslInterceptor");
 
-    constructor(
-        private readonly reflector: Reflector,
-        private readonly caslAbilityFactory: CaslAbilityFactory,
-        private readonly caslHelper: CaslHelper
-    ) {}
+    constructor(private readonly caslAbilityFactory: CaslAbilityFactory, private readonly caslHelper: CaslHelper) {}
 
     async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
         this.logger.verbose("CASL interceptor activated...");
 
-        // Retrieve the Request object from the context. Currently only HTTP and GraphQL supported.
         const req = this.caslHelper.getRequest(context);
 
         // Generate the current user's permissions as of this request if they haven't been generated already.
@@ -45,81 +24,6 @@ export class CaslInterceptor implements NestInterceptor {
             req.permissions = await this.caslAbilityFactory.createForUser(req.user);
         }
 
-        // Retrieve this method's applied rules. TODO: Allow application at the class-level.
-        const rules = this.reflector.get<RuleDef[]>(RULES_METADATA_KEY, context.getHandler());
-
-        let nextRuleFn = () =>
-            next.handle().pipe(
-                tap((value) => {
-                    this.logger.verbose(`Base resolver returned.`);
-                    // If the rule failed, throw a ForbiddenException. We check for req.passed as this allows
-                    //  the actual handler to set this value to true/false if it needs to. This is particularly
-                    //  applicable to mutation handlers (create/update/delete), where you may want to check
-                    //  permissions mid-database transaction. Unlike rules, req.passed defaults to true for
-                    //  handlers.
-                    if (req.passed === false) {
-                        this.logger.debug(
-                            `Base resolver failed (req.passed = ${req.passed}). Throwing ForbiddenException.`
-                        );
-                        // Reset req.passed context variable.
-                        delete req.passed;
-                        throw new ForbiddenException();
-                    }
-                    // Reset req.passed context variable.
-                    delete req.passed;
-                    return value;
-                })
-            );
-
-        if (!rules || rules.length === 0) {
-            this.logger.verbose("No rules applied for the given resource. Checking only for req.passed.");
-        }
-        // Rules are applied recursively, so we need to reverse the order of the rules so that the first rule in the
-        //  list of rules is the first to be called. That rule then calls the next rule, and so on, until the actual
-        //  resolver/handler is called.
-        else
-            for (let i = rules.length - 1; i >= 0; i--) {
-                const rule = rules[i];
-                const ruleNameStr = this.caslHelper.formatRuleName(rule);
-
-                // Cannot pass nextRuleFn directly as it'd pass by reference and cause infinite loop.
-                const nextTemp = nextRuleFn;
-                const handler = this.caslHelper.handlers.get(rule[0]);
-
-                // This should only happen if handlers is not set up properly to define a handler for every
-                //  RuleType.
-                if (!handler) {
-                    throw new Error(`Unsupported rule type ${rule[0]} on ${ruleNameStr}.`);
-                }
-
-                nextRuleFn = () => {
-                    this.logger.verbose(`Initializing rule handler for ${ruleNameStr}`);
-
-                    return handler(context, rule, nextTemp).pipe(
-                        tap((value) => {
-                            this.logger.verbose(`Rule handler for ${ruleNameStr} returned.`);
-
-                            // If the rule failed, throw a ForbiddenException. We check for req.passed as this allows
-                            //  the actual handler to set this value to true/false if it needs to. This is particularly
-                            //  applicable to mutation handlers (create/update/delete), where you may want to check
-                            //  permissions mid-database transaction.
-                            if (!req.passed) {
-                                this.logger.debug(
-                                    `${ruleNameStr} failed (req.passed = ${req.passed}). Throwing ForbiddenException.`
-                                );
-                                // Reset req.passed context variable.
-                                delete req.passed;
-                                throw new ForbiddenException();
-                            }
-
-                            // Reset req.passed context variable.
-                            delete req.passed;
-                            return value;
-                        })
-                    );
-                };
-            }
-
-        return nextRuleFn();
+        return next.handle();
     }
 }

--- a/src/casl/rule-handlers/count.ts
+++ b/src/casl/rule-handlers/count.ts
@@ -1,0 +1,77 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.Count}. This function ensures that the user
+ *  has permission to read at least one resource of the given type, as count resolvers should only be returning the
+ *  count of resources the user has permission to read (as well as match their supplied filter).
+ *
+ *  The user must have {@link AbilityAction.Filter} permission on the field being filtered by. The user's
+ *  ability to read the individual field(s) being filtered is not currently taken into account. As such, it is
+ *  possible for a user to infer some information about fields which they cannot read as long as they have
+ *  permission to filter by them. With complex and combinations of filters, the user may be able to decipher the
+ *  value completely.
+ *
+ *  Currently, filtering permissions cannot have conditions applied to them. It is expected that any sorting or
+ *  filtering permissions that the user has, do not have conditions applied. If they do, the conditions will
+ *  currently be ignored and the user will be able to sort or filter by the field regardless of the conditions.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read the resource type, then this method sets
+ *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
+ *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
+ *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
+ *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument.
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
+ *  mutate the return value from the next handler.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { Observable, of, tap } from "rxjs";
+import { AbilityAction } from "../casl-ability.factory";
+import { CaslHelper } from "../casl.helper";
+
+const logger = new Logger("CountRuleHandler");
+
+export function handleCountRule(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<number | null>,
+    caslHelper: CaslHelper
+): Observable<number | null> {
+    logger.debug("Handling Count rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!req.permissions.can(AbilityAction.Read, subjectStr)) {
+        logger.verbose("Failed basic Count rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    // Make sure user has permission to filter by the fields which they are filtering by.
+    if (!caslHelper.canFilterByFields(context, req, subjectStr, rule.options?.filterInputName ?? "filter")) {
+        logger.verbose("User doesn't have permission to filter by one or more of their supplied filters.");
+        req.passed = false;
+        return of(null);
+    }
+
+    // No permission checks need to be applied to the returned value (it's just a number), so return it.
+    return handler().pipe(tap(() => (req.passed = true)));
+}

--- a/src/casl/rule-handlers/create.ts
+++ b/src/casl/rule-handlers/create.ts
@@ -1,0 +1,106 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.Create}. This function ensures that the user has
+ *  permission to create a resource of the given type, and intercepts the returned value from the resolver/handler
+ *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
+ *  wrapping this method in the {@link this#readOneRuleHandler} method.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read or create the resource, then this method sets
+ *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
+ *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
+ *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
+ *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument.
+ *
+ * @todo Support toggling strict mode?
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
+ *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
+ *  no longer be required.
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
+ *  mutate the return value from the next handler.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { AbilityAction, AbilitySubjects } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { map, Observable, of } from "rxjs";
+import { subject } from "@casl/ability";
+import { CaslHelper } from "../casl.helper";
+import { handleReadOneRule } from "./readOne";
+
+const logger = new Logger("CreateRuleHandler");
+
+export function handleCreateRule<T extends Exclude<AbilitySubjects, string>>(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<T | null>,
+    caslHelper: CaslHelper
+): Observable<T | null> {
+    logger.debug("Handling Create rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!req.permissions.can(AbilityAction.Create, subjectStr)) {
+        logger.verbose("Failed basic Create rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    const inputFields = caslHelper.getInputFields(context, rule.options?.inputName ?? "input");
+
+    // Make sure user can create an object with the fields they've supplied.
+    for (const field of inputFields) {
+        if (!req.permissions.can(AbilityAction.Create, subjectStr, field)) {
+            logger.verbose(`Failed Create rule test for field ${field}.`);
+            req.passed = false;
+            return of(null);
+        }
+    }
+
+    return handler()
+        .pipe(
+            map((newValue) => {
+                // Handler already marked the request as failed for some permission error.
+                if (req.passed === false) {
+                    logger.verbose("Failed Create rule test. Handler already marked as failed.");
+                    return null;
+                }
+
+                const subjectObj = subject(subjectStr, newValue);
+
+                // Check that the user has permission to create an object like this one. If not, prisma tx will roll back.
+                for (const field of Object.keys(newValue)) {
+                    if (!req.permissions.can(AbilityAction.Create, subjectObj, field)) {
+                        logger.verbose(`Failed Create rule test for field ${field} with value.`);
+                        req.passed = false;
+                        return null;
+                    }
+                }
+
+                req.passed = true;
+                return newValue;
+            })
+        )
+        .pipe((v) => {
+            // Make sure user has permission to read the fields they're trying to read after the creation. Creation will
+            //  be rolled back if not.
+            return handleReadOneRule(context, rule, () => v, caslHelper);
+        });
+}

--- a/src/casl/rule-handlers/delete.ts
+++ b/src/casl/rule-handlers/delete.ts
@@ -1,0 +1,98 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.Delete}. This function ensures that the user has
+ *  permission to delete a resource of the given type, and intercepts the returned value from the resolver/handler
+ *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
+ *  wrapping this method in the {@link this#readOneRuleHandler} method.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read or delete the resource, then this method sets
+ *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
+ *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
+ *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
+ *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument.
+ *
+ * @todo Support toggling strict mode?
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
+ *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
+ *  no longer be required.
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
+ *  mutate the return value from the next handler.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { AbilityAction, AbilitySubjects } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { map, Observable, of } from "rxjs";
+import { subject } from "@casl/ability";
+import { handleReadOneRule } from "./readOne";
+import { CaslHelper } from "../casl.helper";
+
+const logger = new Logger("DeleteRuleHandler");
+
+export function handleDeleteRule<T extends Exclude<AbilitySubjects, string>>(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<T | null>,
+    caslHelper: CaslHelper
+): Observable<T | null> {
+    logger.debug("Handling Delete rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!req.permissions.can(AbilityAction.Delete, subjectStr)) {
+        logger.verbose("Failed basic Delete rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    // FIXME currently there is no way to check within the interceptor if the user has permission to delete the
+    //  object to delete before it's been deleted. This check needs to be done in the resolver. This can be solved
+    //  in a future refactor. Technically not required, but it could improve efficiency.
+
+    return handler()
+        .pipe(
+            map((newValue) => {
+                // Handler already marked the request as failed for some permission error.
+                if (req.passed === false) {
+                    logger.verbose("Failed Delete rule test. Handler already marked as failed.");
+                    return null;
+                }
+
+                // Check the user can actually delete the object. Note, the deletion has already happened within the
+                //  transaction at this point. However, if the user doesn't have permission, it'll be rolled back.
+                //  The resolver can also do this before executing the deletion query. See the FIX-ME above.
+                const subjectObj = subject(subjectStr, newValue);
+                if (!req.permissions.can(AbilityAction.Delete, subjectObj)) {
+                    logger.verbose("Failed Delete rule test with value.");
+                    req.passed = false;
+                    return null;
+                }
+
+                req.passed = true;
+                return newValue;
+            })
+        )
+        .pipe((v) => {
+            // Make sure user has permission to read the fields they're trying to read after the deletion. Deletion will
+            //  be rolled back if not.
+            return handleReadOneRule(context, rule, () => v, caslHelper);
+        });
+}

--- a/src/casl/rule-handlers/permissionsFor.ts
+++ b/src/casl/rule-handlers/permissionsFor.ts
@@ -1,0 +1,105 @@
+import { map, Observable } from "rxjs";
+import { subject } from "@casl/ability";
+import { AbilityAction } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { CaslHelper } from "../casl.helper";
+import { PermissionUnion } from "../../types/user_permission/user_permission.resolver";
+
+const logger = new Logger("PermissionsForRuleHandler");
+
+export function handlePermissionsForRule(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<(typeof PermissionUnion)[]>,
+    caslHelper: CaslHelper
+): Observable<(typeof PermissionUnion)[]> {
+    logger.verbose("permissionsFor custom rule handler called");
+    const req = caslHelper.getRequest(context);
+    const fields = caslHelper.getSelectedFields(context);
+
+    const selectedFields: Record<"UserPermission" | "GroupPermission", string[]> = {
+        UserPermission: [],
+        GroupPermission: []
+    };
+
+    // Sanitize the fields to ensure that only the fields that are actually selected are checked. Then,
+    //  check if the user has the ability to read the field. Sanitization simplifies later checks.
+    for (const fieldAndType of fields) {
+        const split = fieldAndType.split(".", 2);
+        const type = split[0];
+        const field = split[1];
+
+        // This should only be __typename.
+        if (type === "Permission") {
+            if (field === "__typename") {
+                continue;
+            }
+            throw new Error(`Unexpected field in permissionsFor custom rule: ${type}.${field}`);
+        }
+
+        if (type !== "GroupPermission" && type !== "UserPermission") {
+            throw new Error("Unexpected type in permissionsFor custom rule: " + type);
+        }
+        selectedFields[type].push(field);
+
+        // if(!req.permissions.can(AbilityAction.Read, type, field)) {
+        //     logger.verbose(`Failed field-base permissionsFor rule test for field "${type}.${field}".`);
+        //     req.passed = false;
+        //     return of(null);
+        // }
+    }
+
+    return handler().pipe(
+        map((values) => {
+            // Handler already marked the request as failed for some permission error.
+            if (req.passed === false) {
+                logger.verbose("Failed permissionsFor rule test. Handler already marked as failed.");
+                return null;
+            }
+
+            // If the value is nullish, there's no value to check, so just return null.
+            if (values === null || values === undefined) {
+                req.passed = true;
+                return null;
+            }
+
+            // Repeat previous tests with the values as the subject.
+
+            for (const value of values) {
+                const subjectStr = "userId" in value ? "UserPermission" : "GroupPermission";
+                const subjectObj = subject(subjectStr, value);
+                if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
+                    logger.verbose("Failed basic permissionsFor rule test on one or more values.");
+                    req.passed = false;
+                    return null;
+                }
+
+                // Test the ability against each requested field with subject value.
+                for (const field of selectedFields[subjectStr]) {
+                    if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
+                        // Strict mode will cause the entire request to fail if any field fails. Otherwise, the field
+                        //  will be set to null. The user won't necessarily know (as of now) whether the field is
+                        //  actually null, or they just can't read it.
+                        if (rule.options?.strict ?? false) {
+                            logger.verbose(
+                                `Failed field-based permissionsFor rule test for field "${subjectStr}.${field}" on one or more values.`
+                            );
+                            req.passed = false;
+                            return null;
+                        } else {
+                            logger.verbose(
+                                `Failed field-based permissionsFor rule test for field "${subjectStr}.${field}" on one value. More may come...`
+                            );
+                            value[field] = null;
+                        }
+                    }
+                }
+            }
+
+            req.passed = true;
+            return values;
+        })
+    );
+}

--- a/src/casl/rule-handlers/readMany.ts
+++ b/src/casl/rule-handlers/readMany.ts
@@ -1,0 +1,201 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.ReadMany}. This function ensures that the user
+ *  has permission to read an array of resources of the given type, and intercepts the returned values from the
+ *  resolver/handler that it is applied to, to make sure the user has permission to read all the returned values.
+ *
+ *  In addition to traditional subject/field permission checks, ReadMany rules also allow for the use of sorting,
+ *  filtering, and pagination. These permissions are handled as such:
+ *
+ *  - <b>Sorting:</b> The user must have {@link AbilityAction.Sort} permission on the field being sorted by. The
+ *    user's ability to read the field(s) being sorted is not currently taken into account. As such, it is possible
+ *    for a user to infer some information about fields which they cannot read as long as they have permission to
+ *    sort by them. With combinations of subsequent sorts, the user may be able to decipher the value completely.
+ *  - <b>Filtering:</b> The user must have {@link AbilityAction.Filter} permission on the field being filtered by.
+ *    The user's ability to read the individual field(s) being filtered is not currently taken into account. As
+ *    such, it is possible for a user to infer some information about fields which they cannot read as long as they
+ *    have permission to filter by them. With complex and combinations of filters, the user may be able to decipher
+ *    the value completely.
+ *  - <b>Pagination:</b> Generally, there are no permission checks against permission necessary. However, if the
+ *    user is using cursor-based pagination, they must have permission to sort by the "ID" field. This is because
+ *    cursor-based pagination requires sorting by some field by its very nature, and the "ID" field is the only
+ *    field which Glimpse currently allows to be used for this. For skip-based pagination, there are no permission
+ *    checks.
+ *
+ *  Currently, sorting and filtering permissions cannot have conditions applied to them. It is expected that any
+ *  sorting or filtering permissions that the user has, do not have conditions applied. If they do, the conditions
+ *  will currently be ignored and the user will be able to sort or filter by the field regardless of the conditions.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read the resources, then this method sets {@link Express.Request#passed}
+ *  to false on the context's request object and returns null, potentially before calling the handler. From there,
+ *  the {@link CaslInterceptor} will see that {@link Request#passed} is false and throw an error.
+ *  {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule is applied to,
+ *  which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument. Namely, strict mode currently applies exclusively to this rule type, allowing you to control what
+ *  happens when the user doesn't have permission to read a field only on a subset of values of the requested type.
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @typeParam T - The type of the array of values expected to be returned by the resolver/handler which this rule
+ *  is being applied to. E.g., if the resolver returns an array of {@link User| Users}, T would be {@link User}.
+ *  Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may no longer be
+ *  required.
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. If the rule's strict mode is
+ *  enabled, then this will return null if the user doesn't have permission to read one or more of the fields on
+ *  any object within the array returned by handler. However, if the rule's strict mode is disabled, then those
+ *  fields will be set to null on the relevant objects. Note that if the user doesn't have permission to read the
+ *  field on <i>any</i> object of the given type, the same behavior as strict mode will occur. That is, null will
+ *  be returned and {@link Express.Request#passed} will be set to false. It is only when the user has permission to
+ *  read the field on some objects of the given type that the strict mode behavior will differ.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { AbilityAction, AbilitySubjects } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { map, Observable, of } from "rxjs";
+import { GqlContextType } from "@nestjs/graphql";
+import { subject } from "@casl/ability";
+import { CaslHelper } from "../casl.helper";
+
+const logger = new Logger("ReadManyRuleHandler");
+
+export function handleReadManyRule<T extends Exclude<AbilitySubjects, string>>(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<T[] | null>,
+    caslHelper: CaslHelper
+): Observable<T[] | null> {
+    logger.debug("Handling ReadMany rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!req.permissions.can(AbilityAction.Read, subjectStr)) {
+        logger.verbose("Failed basic ReadMany rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    // Make sure user has permission to sort by the fields which they are sorting by.
+    if (!caslHelper.canSortByFields(context, req, subjectStr, rule.options?.orderInputName ?? "order")) {
+        logger.verbose("User doesn't have permission to sort by one or more of their supplied sorting arguments.");
+        req.passed = false;
+        return of(null);
+    }
+
+    // Make sure user has permission to filter by the fields which they are filtering by.
+    if (!caslHelper.canFilterByFields(context, req, subjectStr, rule.options?.filterInputName ?? "filter")) {
+        logger.verbose("User doesn't have permission to filter by one or more of their supplied filters.");
+        req.passed = false;
+        return of(null);
+    }
+
+    if (
+        !caslHelper.canPaginate(context, req.permissions, subjectStr, rule.options?.paginationInputName ?? "pagination")
+    ) {
+        logger.verbose(
+            `User supplied cursor-based pagination argument(s) but doesn't have permission to sort by ID on the 
+                    subject "${subjectStr}".`
+        );
+        req.passed = false;
+        return of(null);
+    }
+
+    const fields: Set<string> = new Set();
+    // Field-based tests can only be done pre-resolver for GraphQL requests, since the request includes the
+    //  fields to be returned. Non-GraphQL requests don't include this, as all fields are returned.
+    if (context instanceof GraphQLResolverArgs || context.getType<GqlContextType>() === "graphql") {
+        // getSelectedFields includes type, but we only want the field name.
+        caslHelper.getSelectedFields(context).forEach((v) => fields.add(v.split(".", 2)[1]));
+
+        // Remove any specifically excluded fields from the list of fields.
+        if (rule.options?.excludeFields) {
+            rule.options.excludeFields.forEach((v) => fields.delete(v));
+        }
+
+        // Test the ability against each requested field
+        for (const field of fields) {
+            if (!req.permissions.can(AbilityAction.Read, subjectStr, field)) {
+                logger.verbose(`Failed field-based ReadMany rule test for field "${field}".`);
+                req.passed = false;
+                return of(null);
+            }
+        }
+    }
+
+    // Call next rule, or resolver/handler if no more rules.
+    return handler().pipe(
+        map((values) => {
+            // Handler already marked the request as failed for some permission error.
+            if (req.passed === false) {
+                logger.verbose("Failed ReadMany rule test. Handler already marked as failed.");
+                return null;
+            }
+
+            // If the value is nullish, there's no value to check, so just return null.
+            if (values === null || values === undefined) {
+                req.passed = true;
+                return null;
+            }
+
+            // Repeat previous tests with the values as the subject.
+
+            for (const value of values) {
+                const subjectObj = subject(subjectStr, value);
+                if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
+                    logger.verbose("Failed basic ReadMany rule test on one or more values.");
+                    req.passed = false;
+                    return null;
+                }
+
+                // In GQL contexts, fields were determined pre-resolver. In other contexts, we can only determine them
+                //  post-resolver, which is done here.
+                if (!(context instanceof GraphQLResolverArgs) && context.getType<GqlContextType>() !== "graphql") {
+                    Object.keys(value).forEach((v) => fields.add(v));
+
+                    // Remove any specifically excluded fields from the list of fields.
+                    if (rule.options?.excludeFields) {
+                        rule.options.excludeFields.forEach((v) => fields.delete(v));
+                    }
+                }
+
+                // Test the ability against each requested field with subject value.
+                for (const field of fields) {
+                    if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
+                        // Strict mode will cause the entire request to fail if any field fails. Otherwise, the field
+                        //  will be set to null. The user won't necessarily know (as of now) whether the field is
+                        //  actually null, or they just can't read it.
+                        if (rule.options?.strict ?? false) {
+                            logger.verbose(
+                                `Failed field-based ReadMany rule test for field "${field}" on one or more values.`
+                            );
+                            req.passed = false;
+                            return null;
+                        } else {
+                            logger.verbose(
+                                `Failed field-based ReadMany rule test for field "${field}" on one value. More may come...`
+                            );
+                            value[field] = null;
+                        }
+                    }
+                }
+            }
+
+            req.passed = true;
+            return values;
+        })
+    );
+}

--- a/src/casl/rule-handlers/readOne.ts
+++ b/src/casl/rule-handlers/readOne.ts
@@ -1,0 +1,136 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.ReadOne}. This function ensures that the user has
+ *  permission to read a single resource of the given type, and intercepts the returned value from the
+ *  resolver/handler that it is applied to, to make sure the user has permission to read that specific value.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read the resource, then this method sets {@link Express.Request#passed}
+ *  to false on the context's request object and returns null, potentially before calling the handler. From there,
+ *  the {@link CaslInterceptor} will see that {@link Request#passed} is false and throw an error.
+ *  {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule is applied to,
+ *  which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument.
+ *
+ * @todo Support toggling strict mode?
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
+ *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
+ *  no longer be required.
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
+ *  mutate the return value from the next handler.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { AbilityAction, AbilitySubjects } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { map, Observable, of } from "rxjs";
+import { GqlContextType } from "@nestjs/graphql";
+import { subject } from "@casl/ability";
+import { CaslHelper } from "../casl.helper";
+
+const logger = new Logger("ReadOneRuleHandler");
+
+export function handleReadOneRule<T extends Exclude<AbilitySubjects, string>>(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<T | null>,
+    caslHelper: CaslHelper
+): Observable<T | null> {
+    logger.debug("Handling ReadOne rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!rule.options?.defer && !req.permissions.can(AbilityAction.Read, subjectStr)) {
+        logger.verbose("Failed basic ReadOne rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    const fields: Set<string> = new Set();
+    // Field-based tests can only be done pre-resolver for GraphQL requests, since the request includes the
+    //  fields to be returned. Non-GraphQL requests don't include this, as all fields are returned.
+    if (context instanceof GraphQLResolverArgs || context.getType<GqlContextType>() === "graphql") {
+        // getSelectedFields includes type, but we only want the field name.
+        caslHelper.getSelectedFields(context).forEach((v) => fields.add(v.split(".", 2)[1]));
+
+        // Remove any specifically excluded fields from the list of fields.
+        if (rule.options?.excludeFields) {
+            rule.options.excludeFields.forEach((v) => fields.delete(v));
+        }
+
+        // Test the ability against each requested field
+        for (const field of fields) {
+            if (!rule.options?.defer && !req.permissions.can(AbilityAction.Read, subjectStr, field)) {
+                logger.verbose(`Failed field-based ReadOne rule test for field "${field}".`);
+                req.passed = false;
+                return of(null);
+            }
+        }
+    }
+
+    // Call next rule, or resolver/handler if no more rules.
+    return handler().pipe(
+        map((value) => {
+            // Handler already marked the request as failed for some permission error.
+            if (req.passed === false) {
+                logger.verbose("Failed ReadOne rule test. Handler already marked as failed.");
+                return null;
+            }
+
+            // If the value is nullish, there's no value to check, so just return null.
+            if (value === null || value === undefined) {
+                req.passed = true;
+                return null;
+            }
+
+            // Repeat previous tests with the value as the subject.
+
+            const subjectObj = subject(subjectStr, value);
+
+            if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
+                logger.verbose("Failed basic ReadOne rule test with value as subject.");
+                req.passed = false;
+                return null;
+            }
+
+            // In GQL contexts, fields were determined pre-resolver. In other contexts, we can only determine them
+            //  post-resolver, which is done here.
+            if (!(context instanceof GraphQLResolverArgs) && context.getType<GqlContextType>() !== "graphql") {
+                Object.keys(value).forEach((v) => fields.add(v));
+
+                // Remove any specifically excluded fields from the list of fields.
+                if (rule.options?.excludeFields) {
+                    rule.options.excludeFields.forEach((v) => fields.delete(v));
+                }
+            }
+
+            // Test the ability against each requested field with subject value.
+            for (const field of fields) {
+                if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
+                    logger.verbose(`Failed field-based ReadOne rule test for field "${field}" with value as subject.`);
+                    req.passed = false;
+                    return null;
+                }
+            }
+
+            req.passed = true;
+            return value;
+        })
+    );
+}

--- a/src/casl/rule-handlers/update.ts
+++ b/src/casl/rule-handlers/update.ts
@@ -1,0 +1,111 @@
+/**
+ * Handle a {@link Rule} definition with rule type {@link RuleType.Update}. This function ensures that the user has
+ *  permission to update a resource of the given type, and intercepts the returned value from the resolver/handler
+ *  that it is applied to, to make sure the user has permission to read that specific value. This is done by
+ *  wrapping this method in the {@link this#readOneRuleHandler} method.
+ *
+ *  The current user's permissions are determined by the {@link Express.Request#permissions} property within the
+ *  current NestJS execution context. The {@link CaslInterceptor} is expected to have already initialized this
+ *  value.
+ *
+ *  If the user does not have permission to read or update the resource, then this method sets
+ *  {@link Express.Request#passed} to false on the context's request object and returns null, potentially before
+ *  calling the handler. From there, the {@link CaslInterceptor} will see that {@link Request#passed} is false and
+ *  throw an error. {@link Express.Request#passed} can also be set to false by the resolver/handler that this rule
+ *  is applied to, which stops the rule checks and immediately returns back to the {@link CaslInterceptor}.
+ *
+ *  Options can be supplied to this function to change the behavior of the rule checks within the {@link RuleDef}
+ *  argument.
+ *
+ * @todo Support toggling strict mode?
+ *
+ * @see {@link RuleOptions}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ *
+ * @typeParam T - The type of the value expected to be returned by the resolver/handler which this rule is being
+ *  applied to. Currently, this must be an instance of a valid {@link AbilitySubjects} type. This requirement may
+ *  no longer be required.
+ * @param context - NestJS execution context.
+ * @param rule - Rule to test. If rule type is {@link RuleType.Custom}, an error will be thrown.
+ * @param handler - The handler that calls the request method/resolver, or the next rule/interceptor in line if
+ *  applicable. This is called after the necessary rule checks pass, and then additional checks are applied to the
+ *  return value.
+ * @returns The value returned from the handler, or null if the rule checks fail. This rule handler does not ever
+ *  mutate the return value from the next handler.
+ * @throws Error if the rule type is {@link RuleType.Custom}.
+ * @throws Error if the current user's permissions are not initialized.
+ */
+import { AbilityAction, AbilitySubjects } from "../casl-ability.factory";
+import { ExecutionContext, Logger } from "@nestjs/common";
+import { GraphQLResolverArgs } from "../../gql/graphql-resolver-args.class";
+import { RuleDef } from "../rule.decorator";
+import { map, Observable, of } from "rxjs";
+import { subject } from "@casl/ability";
+import { CaslHelper } from "../casl.helper";
+import { handleReadOneRule } from "./readOne";
+
+const logger = new Logger("UpdateRuleHandler");
+
+export function handleUpdateRule<T extends Exclude<AbilitySubjects, string>>(
+    context: ExecutionContext | GraphQLResolverArgs,
+    rule: RuleDef,
+    handler: () => Observable<T | null>,
+    caslHelper: CaslHelper
+): Observable<T | null> {
+    logger.debug("Handling Update rule.");
+    // Asserts that the rule is not a RuleType.Custom rule.
+    const { req, subjectStr } = caslHelper.getReqAndSubject(context, rule);
+
+    // Basic test with the provided action and subject.
+    if (!req.permissions.can(AbilityAction.Update, subjectStr)) {
+        logger.verbose("Failed basic Update rule test.");
+        req.passed = false;
+        return of(null);
+    }
+
+    const inputFields = caslHelper.getInputFields(context, rule.options?.inputName ?? "input");
+
+    // Make sure user can update an object with the fields they've supplied.
+    for (const field of inputFields) {
+        if (!req.permissions.can(AbilityAction.Update, subjectStr, field)) {
+            logger.verbose(`Failed Update rule test for field ${field}.`);
+            req.passed = false;
+            return of(null);
+        }
+    }
+
+    // FIXME currently there is no way to check within the interceptor if the user has permission to update the
+    //  object to update before it's been updated. This check needs to be done in the resolver. This can be solved
+    //  in a future refactor. Unlike the delete rule, this is a required check.
+
+    return handler()
+        .pipe(
+            map((newValue) => {
+                // Handler already marked the request as failed for some permission error.
+                if (req.passed === false) {
+                    logger.verbose("Failed Update rule test. Handler already marked as failed.");
+                    return null;
+                }
+
+                const subjectObj = subject(subjectStr, newValue);
+
+                // Check that the user has permission to update TO an object like this one. If not, prisma tx will roll
+                //  back.
+                for (const field of inputFields) {
+                    if (!req.permissions.can(AbilityAction.Update, subjectObj, field)) {
+                        logger.verbose(`Failed Update rule test for field ${field} with value.`);
+                        req.passed = false;
+                        return null;
+                    }
+                }
+
+                req.passed = true;
+                return newValue;
+            })
+        )
+        .pipe((v) => {
+            // Make sure user has permission to read the fields they're trying to read after the update. Update will
+            //  be rolled back if not.
+            return handleReadOneRule(context, rule, () => v, caslHelper);
+        });
+}

--- a/src/casl/rule.decorator.ts
+++ b/src/casl/rule.decorator.ts
@@ -13,40 +13,43 @@ import { handleCountRule } from "./rule-handlers/count";
 import * as crypto from "crypto";
 
 /**
- * Rule function that can be used to define a rule for a given controller handler. The rule function takes the current
- *  execution context, the rule definition, and the handler function as arguments. The handler function calls the next
- *  RuleFn in the chain, or the controller if there are no more RuleFns, and returns an {@link Observable} that emits
- *  the result of the handler. This function is expected to then return an {@link Observable} which emits the result to
- *  be returned to the previous handler in the chain, or to the user if there are no handlers further up. If you want a
- *  rule to pass, then you must also set {@link Express.Request#passed} to true. This marks the request as having passed
- *  the rule check, and allows {@link CaslInterceptor} to call the next handler in the chain, and/or to return the value
- *  returned by this function. If {@link Express.Request#passed} is false or undefined, then {@link CaslInterceptor}
- *  will throw a ForbiddenException.
+ * Rule handler that performs checks to make sure a user has permission to access/use a resolver before and after
+ *  execution. The rule handler takes the current context, the rule definition, and the next handler in the chain, and
+ *  an instance of CaslHelper as arguments. If there are no more rule handlers in the chain, then the next handler is
+ *  the resolver. The next function returns an {@link Observable} that emits the result of the next handler/resolver.
+ *  This function is expected to then return an {@link Observable} which emits the result to be returned to the previous
+ *  handler in the chain, or to the user if there are no handlers further up.
+ *
+ *  After calling the next handler, your {@link RuleHandler} should check that {@link Express.Request#passed} is not
+ *  false before continuing. If it is, then the next handler's rule checks failed, and your {@link RuleHandler} should
+ *  throw an error. This system can be improved in the future.
  */
 export type RuleHandler<T = any> = (
     context: ExecutionContext | GraphQLResolverArgs,
     rule: RuleDef,
-    handler: () => Observable<T>,
+    next: () => Observable<T>,
     caslHelper: CaslHelper
 ) => Observable<T>;
 
 /**
- * Valid rule definitions. Rules can either be defined as a {@link RuleType.Custom} rule that uses a function to
- *  check permissions, or as one of the built-in rule types that takes in an {@link AbilitySubjects} as the subject, so
- *  the handler knows how to treat the value(s) in permission checks.
+ * Data structure for a rule definition. A rule definition is a combination of a {@link RuleHandler}, a subject, and
+ *  options. The subject is passed to the {@link RuleHandler} at runtime. The subject can be null if the
+ *  {@link RuleHandler} does not take the subject into account. Otherwise, the subject should be a valid
+ *  {@link AbilitySubjects} value.
  */
 export type RuleDef = {
     fn: RuleHandler;
-    subject: AbilitySubjects;
+    subject: AbilitySubjects | null;
     options?: RuleOptions;
 };
 
 /**
- * Valid types of rules that can be defined. If you want to define a rule other than this, then you should use
- *  {@link RuleType.Custom} and define a custom rule function. If a custom rule is being used frequently, it can be
- *  added to this enum and the handler can be defined and linked within {@link CaslHelper}. The method definitions for
- *  the built-in rules are the same as definitions for {@link RuleType.Custom} rules (i.e., they are all valid
- *  {@link RuleHandler}s).
+ * A set of built-in rule types that can be used to quickly refer to a {@link RuleHandler}. Functionally,
+ *  {@link RuleType}s are just strings which are mapped to {@link RuleHandler}s under the hood. There is no
+ *  implementation difference between using a {@link RuleType} and using a {@link RuleHandler} directly. If you find
+ *  that you are using a {@link RuleHandler} directly frequently, it may make sense to create a {@link RuleType} for
+ *  it, so that you can refer to it by name instead of having to import the {@link RuleHandler} function.
+ *  @see {@link ruleHandlers} for where the {@link RuleType}s are mapped to {@link RuleHandler}s.
  */
 export enum RuleType {
     ReadOne = "ReadOne",
@@ -57,7 +60,7 @@ export enum RuleType {
     Count = "Count"
 }
 
-export const ruleHandlers: Map<RuleType, RuleHandler> = new Map([
+const ruleHandlers: Map<RuleType, RuleHandler> = new Map([
     [RuleType.ReadOne, handleReadOneRule],
     [RuleType.ReadMany, handleReadManyRule],
     [RuleType.Create, handleCreateRule],
@@ -125,10 +128,10 @@ export type RuleOptions = {
      *  whether strict mode is enabled or not. Similarly, if a user requests a subject type which they don't have
      *  permission to read, then a ForbiddenException will be thrown.
      *
-     *  Currently, strict mode only applies to {@link RuleType.ReadMany} rules. For all other rule types, a
-     *  ForbiddenException will be thrown as soon as any rule check fails, regardless of strict mode. Custom rules can
-     *  also implement strict mode, if desired, of course. Check those rules' documentation for more information on how
-     *  it is applied.
+     *  Currently, for the built-in rule types, strict mode only applies to {@link RuleType.ReadMany} rules. For all
+     *  other rule types, a ForbiddenException will be thrown as soon as any rule check fails, regardless of strict
+     *  mode. Custom {@link RuleHandler}s should, but are not required to, also abide by the same guidelines. Check
+     *  those rules' documentation for more information on how it is applied.
      * @default false
      */
     strict?: boolean;
@@ -144,21 +147,75 @@ export type RuleOptions = {
     defer?: boolean;
 };
 
+/**
+ * Map of rule handler IDs to the corresponding registered {@link RuleHandler}s.
+ */
 const registeredHandlers: { [key: string]: RuleHandler } = {};
 
+/**
+ * Perform an MD5 hash on a string. This should not be used for security purposes, as md5 is not considered secure.
+ * @param str String to hash.
+ * @returns The MD5 hash of the string.
+ */
+function md5(str: string): string {
+    return crypto.createHash("md5").update(str).digest("hex");
+}
+
+/**
+ * Compute the automatic ID of a {@link RuleHandler}. This is used to register the handler, when a custom name isn't
+ *  provided. The ID is computed by hashing the handler's function body, and if a hash collision occurs, the hash is
+ *  hashed again until a unique hash is found.
+ * @param handler Handler function to compute the ID of.
+ * @returns The ID of the handler.
+ */
 export function getRuleHandlerId(handler: RuleHandler): string {
-    let hashResult = crypto.createHash("md5").update(handler.toString()).digest("hex");
+    let hashResult = md5(handler.toString());
     // In the event of a hash collision, hash the hash until we get a unique hash.
     while (registeredHandlers[hashResult] && registeredHandlers[hashResult] !== handler) {
-        hashResult = crypto.createHash("md5").update(hashResult).digest("hex");
+        hashResult = md5(hashResult);
     }
     return hashResult;
 }
 
+/**
+ * Get the {@link RuleHandler} for the provided {@link RuleType}. These are considered "built-in" handlers, and can be
+ *  referenced quickly within {@link Rule} decorator calls via their {@link RuleType} value. Generally, you do not need
+ *  to use this method directly, as {@link Rule} will deal with that for you. However, if you need to get the actual
+ *  handler function for some reason, you can use this method to do so.
+ * @param ruleType The {@link RuleType} to get the handler for.
+ * @returns The {@link RuleHandler} for the provided {@link RuleType}. It is considered an error if a RuleType doesn't
+ *  have a corresponding handler, and this should never happen.
+ */
+export function getRuleHandlerForRuleType(ruleType: RuleType): RuleHandler {
+    return ruleHandlers.get(ruleType);
+}
+
+/**
+ * Get the {@link RuleHandler} that has been registered under the provided ID. If no handler has been registered
+ *  under the provided ID, null will be returned.
+ * @param id The ID of the handler to get.
+ * @returns The {@link RuleHandler} that has been registered under the provided ID, or null if no handler has been
+ *  registered under the provided ID.
+ * @see {@link registerHandler}
+ */
 export function getRuleHandler(id: string): RuleHandler | null {
     return registeredHandlers[id] || null;
 }
 
+/**
+ * Register a {@link RuleHandler} to be used with the {@link Rule} decorator. If a name is provided, the handler will
+ *  be registered under that name. Otherwise, the handler will be registered under a hash of its function body.
+ * @param handler The handler to register. Should be a callable function that corresponds with the {@link RuleHandler}
+ *  type.
+ * @param name Optional name to register the handler under. If not provided, the handler will be registered under a
+ *  hash of its function body. If a name is provided but a handler has already been registered under that name, an
+ *  error will be thrown.
+ * @returns The name under which the handler was registered. Also referred to as its ID. In the event of a hash
+ *  collision, this will recursively hash the hash until a unique hash is found.
+ * @throws Error if a handler has already been registered under the provided name.
+ * @see {@link getRuleHandlerId}
+ * @see {@link getRuleHandler}
+ */
 export function registerHandler(handler: RuleHandler, name?: string): string {
     if (name !== undefined) {
         if (registeredHandlers[name]) {
@@ -172,6 +229,12 @@ export function registerHandler(handler: RuleHandler, name?: string): string {
     return hash;
 }
 
+/**
+ * Create a GraphQL AST input string from an object. This is used to create the input for the automatically-generated
+ *  GraphQL @rule directive, where GraphQL input objects are used. Essentially, this is equivalent to
+ *  {@link JSON#stringify} but with the quotations around the keys removed.
+ * @param obj Object to convert to a GraphQL-compatible AST input object as a string.
+ */
 function createAstInputFromObject(obj: Exclude<unknown, undefined>): string {
     let output = "";
 
@@ -197,27 +260,36 @@ function createAstInputFromObject(obj: Exclude<unknown, undefined>): string {
 
 /**
  * Decorator that defines a permission requirement (rule) to the relevant GraphQL resolver. The rule is defined as a
- *  {@link RuleType} and a {@link AbilitySubjects} subject. The rule will use the built-in rule handlers for the given
- *  {@link RuleType} to check if the user has permission to perform the given action on the given subject. If not, then
- *  a ForbiddenException will be thrown by {@link CaslInterceptor}.
+ *  {@link RuleType} or {@link RuleHandler} and optionally a {@link AbilitySubjects} subject.
  *
- *  The controller method will be called by this rule handler. In the case of {@link RuleType.ReadMany}, the value
- *  returned by the resolver/controller handler may be modified if {@link RuleOptions#strict} is set to false.
+ * This decorator can only be applied to GraphQL resolvers, not HTTP controllers. If you need to apply rules to an
+ *  HTTP controller, please open an issue to extend the implementation of this decorator to allow for that. For a
+ *  partial implementation, see the old @Rule decorator implemented with an interceptor at
+ *  {@link https://github.com/rpitv/glimpse-api/tree/03f73f9db27959b07ad83028ae4521187b153ba6/src/casl}. This
+ *  interceptor was deprecated and removed due to being untested and not being needed. For more information, please
+ *  read the wiki.
  *
- *  If you want to perform your own permission checks within the controller method, you can set
- *  {@link Express.Request#passed} to <pre>false</pre> within the controller method. This will tell the rule handler
- *  that the rule check has failed, and a ForbiddenException will be thrown by {@link CaslInterceptor} as soon as the
- *  resolver/controller handler returns.
- * @param type Type of rule to define. For this overload, this must not be {@link RuleType.Custom}.
- * @param subject {@link AbilitySubjects} subject to check permission for.
+ *  The resolver method will be called by the rule handler if its rule checks pass. It is also possible for the rule
+ *  handler to apply checks on the return result of the resolver. If those rule checks fail, any mutations made within
+ *  the resolver will be rolled back.
+ *
+ *  Rule handlers are free to also mutate the return result from the resolver. Of the built-in {@link RuleType}s, the
+ *  only one that mutates the result is {@link RuleType.ReadMany}. If {@link RuleOptions#strict} is set to true, then
+ *  rule handlers should not mutate the result, instead completely failing the request by throwing an error.
+ *
+ *  If you want to perform your own permission checks within the resolver, you can set {@link Express.Request#passed}
+ *  to <pre>false</pre> within the controller method. This will tell the rule handler that the rule check has failed,
+ *  and a ForbiddenException should be thrown by the rule handler as soon as the resolver returns.
+ *
+ *  TODO Setting {@link Express.Request#passed} to <pre>false</pre> will currently have no effect if there are no rules
+ *   applied to the resolver.
+ * @param handler The {@link RuleHandler} function implementation to use for this rule. Alternatively, a
+ *  {@link RuleType} may be provided, in which case the default rule handler for that type will be used.
+ * @param subj {@link AbilitySubjects} subject to check permission for. May be null, however some rule handlers may
+ *  require a non-null subject and throw an error when a null subject is provided.
  * @param options Optional {@link RuleOptions} to configure this rule.
- * @constructor
- * @param handler
- * @param subj
- * @param options
- * @constructor
  */
-export function Rule(handler: RuleHandler | RuleType, subj: AbilitySubjects, options?: RuleOptions) {
+export function Rule(handler: RuleHandler | RuleType, subj: AbilitySubjects | null, options?: RuleOptions) {
     if (typeof handler !== "function") {
         const strHandler = handler as RuleType;
         handler = ruleHandlers.get(handler);
@@ -248,6 +320,6 @@ export function Rule(handler: RuleHandler | RuleType, subj: AbilitySubjects, opt
     if (options !== undefined) {
         optionsAstString = `, options: ${createAstInputFromObject(options)}`;
     }
-    console.log(optionsAstString);
+
     return Directive(`@rule(id: "${handlerId}", subject: ${subjStr}${optionsAstString})`);
 }

--- a/src/casl/rule.directive.ts
+++ b/src/casl/rule.directive.ts
@@ -1,12 +1,6 @@
 import { DirectiveLocation, getDirective, MapperKind, mapSchema } from "@graphql-tools/utils";
 import { defaultFieldResolver, GraphQLNonNull, GraphQLSchema } from "graphql";
-import {
-    GraphQLBoolean,
-    GraphQLDirective,
-    GraphQLInputObjectType,
-    GraphQLList,
-    GraphQLString
-} from "graphql/type";
+import { GraphQLBoolean, GraphQLDirective, GraphQLInputObjectType, GraphQLList, GraphQLString } from "graphql/type";
 import { AbilitySubjects, GraphQLAbilitySubjectsType } from "./casl-ability.factory";
 import { CaslHelper } from "./casl.helper";
 import { ForbiddenException, Injectable, Logger } from "@nestjs/common";

--- a/src/casl/rule.directive.ts
+++ b/src/casl/rule.directive.ts
@@ -3,29 +3,34 @@ import { defaultFieldResolver, GraphQLNonNull, GraphQLSchema } from "graphql";
 import {
     GraphQLBoolean,
     GraphQLDirective,
-    GraphQLEnumType,
     GraphQLInputObjectType,
     GraphQLList,
     GraphQLString
 } from "graphql/type";
-import { RuleDef, RuleFn, RuleType } from "./rule.decorator";
-import { AbilityAction, GraphQLAbilitySubjectsType } from "./casl-ability.factory";
+import { AbilitySubjects, GraphQLAbilitySubjectsType } from "./casl-ability.factory";
 import { CaslHelper } from "./casl.helper";
 import { ForbiddenException, Injectable, Logger } from "@nestjs/common";
-import { defer, firstValueFrom, map, Observable, tap } from "rxjs";
+import { defer, firstValueFrom, Observable, tap } from "rxjs";
 import { GraphQLResolverArgs } from "../gql/graphql-resolver-args.class";
-import { subject } from "@casl/ability";
+import { getRuleHandler, RuleDef, RuleHandler, RuleOptions } from "./rule.decorator";
 
 /**
- * Injectable class for defining a GraphQL directive that can be used to apply CASL rules to a field. This directive
- *  operates almost identically to the @{@link Rule}() decorator, but is intended to be used in a GraphQL schema.
- *  The {@link Rule} decorator cannot be used in a GraphQL context as NestJS interceptors are only capable of
- *  encapsulating top-level resolver functions.
+ * Injectable class for defining the GraphQL directives that can be used to apply CASL rules to a field. This is an
+ *  underlying implementation. In reality, you'll probably want to use the {@link Rule} decorator instead, which
+ *  is just a type-safe wrapper for applying these directives. Thus, you may find more complete documentation within
+ *  the {@link Rule} decorator.
  *
- *  Currently, custom rule types are not supported by this directive.
+ * These directives can only be applied to GraphQL resolvers, not HTTP controllers. If you need to apply rules to an
+ *  HTTP controller, you will need to implement an interceptor which calls the underlying logic within
+ *  {@link CaslHelper}. For a partial implementation, see the old @Rule decorator implemented with an interceptor at
+ *  {@link https://github.com/rpitv/glimpse-api/tree/03f73f9db27959b07ad83028ae4521187b153ba6/src/casl}. This
+ *  interceptor was deprecated and removed due to being untested and not being needed. For more information, please
+ *  read the wiki.
  *
- *  @see {@link Rule} for HTTP counterpart and full documentation.
- *  @see {@link https://github.com/nestjs/graphql/issues/631}
+ * @see {@link https://github.com/rpitv/glimpse-api/tree/03f73f9db27959b07ad83028ae4521187b153ba6/src/casl}
+ * @see {@link https://github.com/rpitv/glimpse-api/wiki/Authorization}
+ * @see {@link https://github.com/nestjs/graphql/issues/631}
+ * @see {@link Rule} for type-safe wrapper
  */
 @Injectable()
 export class RuleDirective {
@@ -33,102 +38,15 @@ export class RuleDirective {
 
     constructor(private readonly caslHelper: CaslHelper) {}
 
-    private customRules: Record<string, RuleFn> = {
-        permissionsFor: (ctx, rule, handler) => {
-            this.logger.verbose("permissionsFor custom rule handler called");
-            const req = this.caslHelper.getRequest(ctx);
-            const fields = this.caslHelper.getSelectedFields(ctx);
-
-            const selectedFields: Record<"UserPermission" | "GroupPermission", string[]> = {
-                UserPermission: [],
-                GroupPermission: []
-            };
-
-            // Sanitize the fields to ensure that only the fields that are actually selected are checked. Then,
-            //  check if the user has the ability to read the field. Sanitization simplifies later checks.
-            for (const fieldAndType of fields) {
-                const split = fieldAndType.split(".", 2);
-                const type = split[0];
-                const field = split[1];
-
-                // This should only be __typename.
-                if (type === "Permission") {
-                    if (field === "__typename") {
-                        continue;
-                    }
-                    throw new Error(`Unexpected field in permissionsFor custom rule: ${type}.${field}`);
-                }
-
-                if (type !== "GroupPermission" && type !== "UserPermission") {
-                    throw new Error("Unexpected type in permissionsFor custom rule: " + type);
-                }
-                selectedFields[type].push(field);
-
-                // if(!req.permissions.can(AbilityAction.Read, type, field)) {
-                //     this.logger.verbose(`Failed field-base permissionsFor rule test for field "${type}.${field}".`);
-                //     req.passed = false;
-                //     return of(null);
-                // }
-            }
-
-            return handler().pipe(
-                map((values) => {
-                    // Handler already marked the request as failed for some permission error.
-                    if (req.passed === false) {
-                        this.logger.verbose("Failed permissionsFor rule test. Handler already marked as failed.");
-                        return null;
-                    }
-
-                    // If the value is nullish, there's no value to check, so just return null.
-                    if (values === null || values === undefined) {
-                        req.passed = true;
-                        return null;
-                    }
-
-                    // Repeat previous tests with the values as the subject.
-
-                    for (const value of values) {
-                        const subjectStr = "userId" in value ? "UserPermission" : "GroupPermission";
-                        const subjectObj = subject(subjectStr, value);
-                        if (!req.permissions.can(AbilityAction.Read, subjectObj)) {
-                            this.logger.verbose("Failed basic permissionsFor rule test on one or more values.");
-                            req.passed = false;
-                            return null;
-                        }
-
-                        // Test the ability against each requested field with subject value.
-                        for (const field of selectedFields[subjectStr]) {
-                            if (!req.permissions.can(AbilityAction.Read, subjectObj, field)) {
-                                // Strict mode will cause the entire request to fail if any field fails. Otherwise, the field
-                                //  will be set to null. The user won't necessarily know (as of now) whether the field is
-                                //  actually null, or they just can't read it.
-                                if (rule[2]?.strict ?? false) {
-                                    this.logger.verbose(
-                                        `Failed field-based permissionsFor rule test for field "${subjectStr}.${field}" on one or more values.`
-                                    );
-                                    req.passed = false;
-                                    return null;
-                                } else {
-                                    this.logger.verbose(
-                                        `Failed field-based permissionsFor rule test for field "${subjectStr}.${field}" on one value. More may come...`
-                                    );
-                                    value[field] = null;
-                                }
-                            }
-                        }
-                    }
-
-                    req.passed = true;
-                    return values;
-                })
-            );
-        }
-    } as const;
-
     createBasic(schema: GraphQLSchema, directiveName: string) {
         return mapSchema(schema, {
             [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
-                const rules = getDirective(schema, fieldConfig, directiveName);
+                type RuleInput = {
+                    id: string;
+                    subject: Extract<AbilitySubjects, string> | null;
+                    options?: RuleOptions;
+                };
+                const rules: RuleInput[] = getDirective(schema, fieldConfig, directiveName) as RuleInput[];
 
                 if (rules && rules.length > 0) {
                     const { resolve = defaultFieldResolver } = fieldConfig;
@@ -157,114 +75,26 @@ export class RuleDirective {
                         };
 
                         for (let i = rules.length - 1; i >= 0; i--) {
-                            const rule: RuleDef = [rules[i].ruleType, rules[i].subject, rules[i].options];
-                            const ruleNameStr = this.caslHelper.formatRuleName(rule);
-
-                            // Cannot pass nextRuleFn directly as it'd pass by reference and cause infinite loop.
-                            const nextTemp = nextRuleFn;
-                            const handler = this.caslHelper.handlers.get(rule[0]);
-
-                            // This should only happen if handlers is not set up properly to define a handler for every
-                            //  RuleType.
-                            if (!handler) {
-                                throw new Error(`Unsupported rule type ${rule[0]} on ${ruleNameStr}.`);
-                            }
-
-                            nextRuleFn = () => {
-                                this.logger.verbose(`Initializing rule handler for ${ruleNameStr}`);
-
-                                return handler(resolverArgs, rule, nextTemp).pipe(
-                                    tap((value) => {
-                                        this.logger.verbose(`Rule handler for ${ruleNameStr} returned.`);
-
-                                        // If the rule failed, throw a ForbiddenException. We check for req.passed as
-                                        //  this allows the actual handler to set this value to true/false if it needs
-                                        //  to. This is particularly applicable to mutation handlers
-                                        //  (create/update/delete), where you may want to check permissions mid-database
-                                        //  transaction.
-                                        if (!context.req.passed) {
-                                            this.logger.debug(
-                                                `${ruleNameStr} failed (req.passed = ${context.req.passed}). Throwing 
-                                                ForbiddenException.`
-                                            );
-                                            // Reset req.passed context variable.
-                                            delete context.req.passed;
-                                            throw new ForbiddenException();
-                                        }
-
-                                        // Reset req.passed context variable.
-                                        delete context.req.passed;
-                                        return value;
-                                    })
-                                );
+                            const handler: RuleHandler = getRuleHandler(rules[i].id);
+                            const rule: RuleDef = {
+                                fn: handler,
+                                subject: rules[i].subject,
+                                options: rules[i].options
                             };
-                        }
-
-                        return await firstValueFrom(nextRuleFn());
-                    };
-                    return fieldConfig;
-                }
-            }
-        });
-    }
-
-    createCustom(schema: GraphQLSchema, directiveName: string) {
-        return mapSchema(schema, {
-            [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
-                const rules = getDirective(schema, fieldConfig, directiveName);
-
-                if (rules && rules.length > 0) {
-                    // Assert that all custom rules are defined while the app is initializing.
-                    for (let i = rules.length - 1; i >= 0; i--) {
-                        const customRuleFn = this.customRules[rules[i].name];
-                        if (!customRuleFn) {
-                            throw new Error(`Custom rule "${rules[i].name}" not found.`);
-                        }
-                    }
-
-                    const { resolve = defaultFieldResolver } = fieldConfig;
-
-                    // Replace the original resolver with a function that *first* calls
-                    // the original resolver, then converts its result to upper case
-                    fieldConfig.resolve = async (source, args, context, info) => {
-                        const resolverArgs = new GraphQLResolverArgs(source, args, context, info);
-                        let nextRuleFn = (): Observable<any> => {
-                            return defer(async () => {
-                                const result = resolve(source, args, context, info);
-                                // If the resolver explicitly said that the request should fail, throw a
-                                //  ForbiddenException.
-                                if (context.req.passed === false) {
-                                    this.logger.debug(
-                                        `Resolver failed (req.passed = ${context.req.passed}). Throwing 
-                                        ForbiddenException.`
-                                    );
-                                    // Reset req.passed context variable.
-                                    delete context.req.passed;
-                                    throw new ForbiddenException();
-                                }
-
-                                return result;
-                            });
-                        };
-
-                        for (let i = rules.length - 1; i >= 0; i--) {
-                            const customRuleFn = this.customRules[rules[i].name];
-                            const rule: RuleDef = [RuleType.Custom, customRuleFn, rules[i].options];
                             const ruleNameStr = this.caslHelper.formatRuleName(rule);
 
                             // Cannot pass nextRuleFn directly as it'd pass by reference and cause infinite loop.
                             const nextTemp = nextRuleFn;
-                            const handler = customRuleFn;
 
                             nextRuleFn = () => {
                                 this.logger.verbose(`Initializing rule handler for ${ruleNameStr}`);
 
-                                return handler(resolverArgs, rule, nextTemp).pipe(
+                                return rule.fn(resolverArgs, rule, nextTemp, this.caslHelper).pipe(
                                     tap((value) => {
                                         this.logger.verbose(`Rule handler for ${ruleNameStr} returned.`);
 
                                         // If the rule failed, throw a ForbiddenException. We check for req.passed as
-                                        //  this allows the actual handler to set this value to true/false if it needs
+                                        //  this allows the actual ruleHandler to set this value to true/false if it needs
                                         //  to. This is particularly applicable to mutation handlers
                                         //  (create/update/delete), where you may want to check permissions mid-database
                                         //  transaction.
@@ -294,20 +124,6 @@ export class RuleDirective {
         });
     }
 }
-
-/**
- * A GraphQL enum type for the {@link RuleType} enum.
- */
-export const GraphQLRuleType = new GraphQLEnumType({
-    name: "RuleType",
-    values: Object.keys(RuleType).reduce((values, type) => {
-        // Custom is skipped here because custom rules are applied via the @custom_rule directive.
-        if (type !== "Custom") {
-            values[type] = { value: type };
-        }
-        return values;
-    }, {})
-});
 
 /**
  * Based on {@link RuleOptions} type. Can't think of an easy way to infer this from the RuleOptions type.
@@ -352,31 +168,11 @@ export const GraphQLRuleDirective = new GraphQLDirective({
     name: "rule",
     locations: [DirectiveLocation.FIELD_DEFINITION],
     args: {
-        ruleType: {
-            type: GraphQLRuleType
+        id: {
+            type: new GraphQLNonNull(GraphQLString)
         },
         subject: {
             type: GraphQLAbilitySubjectsType
-        },
-        options: {
-            type: GraphQLRuleOptionsInput
-        }
-    }
-});
-
-/**
- * GraphQL custom rule directive definition which is passed to the GraphQL module in app.module.ts. This directive can
- *  be applied to field resolvers to apply a custom rule to the field. Custom rules reference functions defined in the
- *  {@link RuleDirective#customRules} map. We use this instead of the @Rule decorator because of limitations with NestJS
- *  interceptors in GraphQL contexts.
- *  @see {@link https://github.com/nestjs/graphql/issues/631}
- */
-export const GraphQLCustomRuleDirective = new GraphQLDirective({
-    name: "custom_rule",
-    locations: [DirectiveLocation.FIELD_DEFINITION],
-    args: {
-        name: {
-            type: new GraphQLNonNull(GraphQLString)
         },
         options: {
             type: GraphQLRuleOptionsInput

--- a/src/types/access_log/access_log.resolver.ts
+++ b/src/types/access_log/access_log.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { AccessLog } from "./access_log.entity";
 import { Logger } from "@nestjs/common";
 import { accessibleBy } from "@casl/prisma";
@@ -9,6 +9,7 @@ import { Complexities } from "../../gql/gql-complexity.plugin";
 import { Request } from "express";
 import { User } from "../user/user.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => AccessLog)
 export class AccessLogResolver {
@@ -17,7 +18,7 @@ export class AccessLogResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [AccessLog], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: AccessLog)")
+    @Rule(RuleType.ReadMany, AccessLog)
     async findManyAccessLog(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAccessLogInput, nullable: true }) filter?: FilterAccessLogInput,
@@ -45,7 +46,7 @@ export class AccessLogResolver {
     }
 
     @Query(() => AccessLog, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: AccessLog)")
+    @Rule(RuleType.ReadOne, AccessLog)
     async findOneAccessLog(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -59,7 +60,7 @@ export class AccessLogResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: AccessLog)")
+    @Rule(RuleType.Count, AccessLog)
     async accessLogCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAccessLogInput, nullable: true }) filter?: FilterAccessLogInput
@@ -77,7 +78,7 @@ export class AccessLogResolver {
      * Virtual field resolver for the User corresponding to the AccessLog's {@link AccessLog#userId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async user(@Context() ctx: { req: Request }, @Parent() accessLog: AccessLog): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/alert_log/alert_log.resolver.ts
+++ b/src/types/alert_log/alert_log.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { OrderAlertLogInput } from "./dto/order-alert_log.input";
 import { CreateAlertLogInput } from "./dto/create-alert_log.input";
 import { UpdateAlertLogInput } from "./dto/update-alert_log.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => AlertLog)
 export class AlertLogResolver {
@@ -22,7 +23,7 @@ export class AlertLogResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [AlertLog], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: AlertLog)")
+    @Rule(RuleType.ReadMany, AlertLog)
     async findManyAlertLog(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAlertLogInput, nullable: true }) filter?: FilterAlertLogInput,
@@ -50,7 +51,7 @@ export class AlertLogResolver {
     }
 
     @Query(() => AlertLog, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: AlertLog)")
+    @Rule(RuleType.ReadOne, AlertLog)
     async findOneAlertLog(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -64,7 +65,7 @@ export class AlertLogResolver {
     }
 
     @Mutation(() => AlertLog, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: AlertLog)")
+    @Rule(RuleType.Create, AlertLog)
     async createAlertLog(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateAlertLogInput }) input: CreateAlertLogInput
@@ -92,7 +93,7 @@ export class AlertLogResolver {
     }
 
     @Mutation(() => AlertLog, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: AlertLog)")
+    @Rule(RuleType.Update, AlertLog)
     async updateAlertLog(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -144,7 +145,7 @@ export class AlertLogResolver {
     }
 
     @Mutation(() => AlertLog, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: AlertLog)")
+    @Rule(RuleType.Delete, AlertLog)
     async deleteAlertLog(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -185,7 +186,7 @@ export class AlertLogResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: AlertLog)")
+    @Rule(RuleType.Count, AlertLog)
     async alertLogCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAlertLogInput, nullable: true }) filter?: FilterAlertLogInput

--- a/src/types/asset/asset.resolver.ts
+++ b/src/types/asset/asset.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -15,6 +15,7 @@ import { CreateAssetInput } from "./dto/create-asset.input";
 import { OrderAssetInput } from "./dto/order-asset.input";
 import { User } from "../user/user.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Asset)
 export class AssetResolver {
@@ -23,7 +24,7 @@ export class AssetResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Asset], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Asset)")
+    @Rule(RuleType.ReadMany, Asset)
     async findManyAsset(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAssetInput, nullable: true }) filter?: FilterAssetInput,
@@ -51,7 +52,7 @@ export class AssetResolver {
     }
 
     @Query(() => Asset, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Asset)")
+    @Rule(RuleType.ReadOne, Asset)
     async findOneAsset(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -65,7 +66,7 @@ export class AssetResolver {
     }
 
     @Mutation(() => Asset, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Asset)")
+    @Rule(RuleType.Create, Asset)
     async createAsset(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateAssetInput }) input: CreateAssetInput
@@ -93,7 +94,7 @@ export class AssetResolver {
     }
 
     @Mutation(() => Asset, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Asset)")
+    @Rule(RuleType.Update, Asset)
     async updateAsset(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -145,7 +146,7 @@ export class AssetResolver {
     }
 
     @Mutation(() => Asset, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Asset)")
+    @Rule(RuleType.Delete, Asset)
     async deleteAsset(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -186,7 +187,7 @@ export class AssetResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Asset)")
+    @Rule(RuleType.Count, Asset)
     async assetCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAssetInput, nullable: true }) filter?: FilterAssetInput
@@ -204,7 +205,7 @@ export class AssetResolver {
      * Virtual field resolver for the User corresponding to the Asset's {@link Asset#lastKnownHandlerId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async lastKnownHandler(@Context() ctx: { req: Request }, @Parent() asset: Asset): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -221,7 +222,7 @@ export class AssetResolver {
      * Virtual field resolver for the Asset corresponding to the Asset's {@link Asset#parentId}.
      */
     @ResolveField(() => Asset, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Asset)")
+    @Rule(RuleType.ReadOne, Asset)
     async parent(@Context() ctx: { req: Request }, @Parent() asset: Asset): Promise<Asset> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -238,7 +239,7 @@ export class AssetResolver {
      * Virtual field resolver for all Assets which have this Asset as their {@link Asset#parentId}.
      */
     @ResolveField(() => [Asset], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Asset)")
+    @Rule(RuleType.ReadMany, Asset)
     async children(
         @Context() ctx: { req: Request },
         @Parent() asset: Asset,

--- a/src/types/audit_log/audit_log.resolver.ts
+++ b/src/types/audit_log/audit_log.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { Logger } from "@nestjs/common";
 import { accessibleBy } from "@casl/prisma";
 import PaginationInput from "../../gql/pagination.input";
@@ -10,6 +10,7 @@ import { OrderAuditLogInput } from "./dto/order-audit_log.input";
 import { AbilitySubjects } from "../../casl/casl-ability.factory";
 import { User } from "../user/user.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => AuditLog)
 export class AuditLogResolver {
@@ -28,7 +29,7 @@ export class AuditLogResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [AuditLog], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: AuditLog)")
+    @Rule(RuleType.ReadMany, AuditLog)
     async findManyAuditLog(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAuditLogInput, nullable: true }) filter?: FilterAuditLogInput,
@@ -56,7 +57,7 @@ export class AuditLogResolver {
     }
 
     @Query(() => AuditLog, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: AuditLog)")
+    @Rule(RuleType.ReadOne, AuditLog)
     async findOneAuditLog(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -70,7 +71,7 @@ export class AuditLogResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: AuditLog)")
+    @Rule(RuleType.Count, AuditLog)
     async auditLogCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterAuditLogInput, nullable: true }) filter?: FilterAuditLogInput
@@ -147,7 +148,7 @@ export class AuditLogResolver {
      * Virtual field resolver for the User corresponding to the AuditLog's {@link AuditLog#userId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async user(@Context() ctx: { req: Request }, @Parent() auditLog: AuditLog): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/blog_post/blog_post.resolver.ts
+++ b/src/types/blog_post/blog_post.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -15,6 +15,7 @@ import { CreateBlogPostInput } from "./dto/create-blog_post.input";
 import { UpdateBlogPostInput } from "./dto/update-blog_post.input";
 import { Person } from "../person/person.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => BlogPost)
 export class BlogPostResolver {
@@ -23,7 +24,7 @@ export class BlogPostResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [BlogPost], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: BlogPost)")
+    @Rule(RuleType.ReadMany, BlogPost)
     async findManyBlogPost(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterBlogPostInput, nullable: true }) filter?: FilterBlogPostInput,
@@ -51,7 +52,7 @@ export class BlogPostResolver {
     }
 
     @Query(() => BlogPost, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: BlogPost)")
+    @Rule(RuleType.ReadOne, BlogPost)
     async findOneBlogPost(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -65,7 +66,7 @@ export class BlogPostResolver {
     }
 
     @Mutation(() => BlogPost, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: BlogPost)")
+    @Rule(RuleType.Create, BlogPost)
     async createBlogPost(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateBlogPostInput }) input: CreateBlogPostInput
@@ -93,7 +94,7 @@ export class BlogPostResolver {
     }
 
     @Mutation(() => BlogPost, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: BlogPost)")
+    @Rule(RuleType.Update, BlogPost)
     async updateBlogPost(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -145,7 +146,7 @@ export class BlogPostResolver {
     }
 
     @Mutation(() => BlogPost, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: BlogPost)")
+    @Rule(RuleType.Delete, BlogPost)
     async deleteBlogPost(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -186,7 +187,7 @@ export class BlogPostResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: BlogPost)")
+    @Rule(RuleType.Count, BlogPost)
     async blogPostCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterBlogPostInput, nullable: true }) filter?: FilterBlogPostInput
@@ -204,7 +205,7 @@ export class BlogPostResolver {
      * Virtual field resolver for the Person corresponding to the BlogPost's {@link BlogPost#authorId}.
      */
     @ResolveField(() => Person, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async author(@Context() ctx: { req: Request }, @Parent() blogPost: BlogPost): Promise<Person> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/category/category.resolver.ts
+++ b/src/types/category/category.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -17,6 +17,7 @@ import { Production } from "../production/production.entity";
 import { FilterProductionInput } from "../production/dto/filter-production.input";
 import { OrderProductionInput } from "../production/dto/order-production.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Category)
 export class CategoryResolver {
@@ -25,7 +26,7 @@ export class CategoryResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Category], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Category)")
+    @Rule(RuleType.ReadMany, Category)
     async findManyCategory(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterCategoryInput, nullable: true }) filter?: FilterCategoryInput,
@@ -53,7 +54,7 @@ export class CategoryResolver {
     }
 
     @Query(() => Category, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Category)")
+    @Rule(RuleType.ReadOne, Category)
     async findOneCategory(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -67,7 +68,7 @@ export class CategoryResolver {
     }
 
     @Mutation(() => Category, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Category)")
+    @Rule(RuleType.Create, Category)
     async createCategory(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateCategoryInput }) input: CreateCategoryInput
@@ -95,7 +96,7 @@ export class CategoryResolver {
     }
 
     @Mutation(() => Category, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Category)")
+    @Rule(RuleType.Update, Category)
     async updateCategory(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -147,7 +148,7 @@ export class CategoryResolver {
     }
 
     @Mutation(() => Category, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Category)")
+    @Rule(RuleType.Delete, Category)
     async deleteCategory(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -188,7 +189,7 @@ export class CategoryResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Category)")
+    @Rule(RuleType.Count, Category)
     async categoryCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterCategoryInput, nullable: true }) filter?: FilterCategoryInput
@@ -206,7 +207,7 @@ export class CategoryResolver {
      * Virtual field resolver for the Category corresponding to the Category's {@link Category#parentId}.
      */
     @ResolveField(() => Category, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Category)")
+    @Rule(RuleType.ReadOne, Category)
     async parent(@Context() ctx: { req: Request }, @Parent() category: Category): Promise<Category> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -223,7 +224,7 @@ export class CategoryResolver {
      * Virtual field resolver for all Categories which have this Category as their {@link Category#parentId}.
      */
     @ResolveField(() => [Category], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Category)")
+    @Rule(RuleType.ReadMany, Category)
     async children(
         @Context() ctx: { req: Request },
         @Parent() category: Category,
@@ -257,7 +258,7 @@ export class CategoryResolver {
      * Virtual field resolver for all Productions which have this Category as their {@link Production#categoryId}.
      */
     @ResolveField(() => [Production], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Production)")
+    @Rule(RuleType.ReadMany, Production)
     async productions(
         @Context() ctx: { req: Request },
         @Parent() category: Category,

--- a/src/types/contact_submissions/contact_submission.resolver.ts
+++ b/src/types/contact_submissions/contact_submission.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { OrderContactSubmissionInput } from "./dto/order-contact_submission.inpu
 import { CreateContactSubmissionInput } from "./dto/create-contact_submission.input";
 import { UpdateContactSubmissionInput } from "./dto/update-contact_submission.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => ContactSubmission)
 export class ContactSubmissionResolver {
@@ -22,7 +23,7 @@ export class ContactSubmissionResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [ContactSubmission], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: ContactSubmission)")
+    @Rule(RuleType.ReadMany, ContactSubmission)
     async findManyContactSubmission(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterContactSubmissionInput, nullable: true })
@@ -52,7 +53,7 @@ export class ContactSubmissionResolver {
     }
 
     @Query(() => ContactSubmission, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: ContactSubmission)")
+    @Rule(RuleType.ReadOne, ContactSubmission)
     async findOneContactSubmission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -66,7 +67,7 @@ export class ContactSubmissionResolver {
     }
 
     @Mutation(() => ContactSubmission, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: ContactSubmission)")
+    @Rule(RuleType.Create, ContactSubmission)
     async createContactSubmission(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateContactSubmissionInput }) input: CreateContactSubmissionInput
@@ -94,7 +95,7 @@ export class ContactSubmissionResolver {
     }
 
     @Mutation(() => ContactSubmission, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: ContactSubmission)")
+    @Rule(RuleType.Update, ContactSubmission)
     async updateContactSubmission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -146,7 +147,7 @@ export class ContactSubmissionResolver {
     }
 
     @Mutation(() => ContactSubmission, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: ContactSubmission)")
+    @Rule(RuleType.Delete, ContactSubmission)
     async deleteContactSubmission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -187,7 +188,7 @@ export class ContactSubmissionResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: ContactSubmission)")
+    @Rule(RuleType.Count, ContactSubmission)
     async contactSubmissionCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterContactSubmissionInput, nullable: true })

--- a/src/types/credit/credit.resolver.ts
+++ b/src/types/credit/credit.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -16,6 +16,7 @@ import { UpdateCreditInput } from "./dto/update-credit.input";
 import { Person } from "../person/person.entity";
 import { Production } from "../production/production.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Credit)
 export class CreditResolver {
@@ -24,7 +25,7 @@ export class CreditResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Credit], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Credit)")
+    @Rule(RuleType.ReadMany, Credit)
     async findManyCredit(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterCreditInput, nullable: true }) filter?: FilterCreditInput,
@@ -52,7 +53,7 @@ export class CreditResolver {
     }
 
     @Query(() => Credit, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Credit)")
+    @Rule(RuleType.ReadOne, Credit)
     async findOneCredit(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -66,7 +67,7 @@ export class CreditResolver {
     }
 
     @Mutation(() => Credit, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Credit)")
+    @Rule(RuleType.Create, Credit)
     async createCredit(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateCreditInput }) input: CreateCreditInput
@@ -94,7 +95,7 @@ export class CreditResolver {
     }
 
     @Mutation(() => Credit, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Credit)")
+    @Rule(RuleType.Update, Credit)
     async updateCredit(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -146,7 +147,7 @@ export class CreditResolver {
     }
 
     @Mutation(() => Credit, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Credit)")
+    @Rule(RuleType.Delete, Credit)
     async deleteCredit(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -187,7 +188,7 @@ export class CreditResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Credit)")
+    @Rule(RuleType.Count, Credit)
     async creditCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterCreditInput, nullable: true }) filter?: FilterCreditInput
@@ -205,7 +206,7 @@ export class CreditResolver {
      * Virtual field resolver for the Person corresponding to the Credit's {@link Credit#personId}.
      */
     @ResolveField(() => Person, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async person(@Context() ctx: { req: Request }, @Parent() credit: Credit): Promise<Person> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -222,7 +223,7 @@ export class CreditResolver {
      * Virtual field resolver for the Production corresponding to the Credit's {@link Credit#productionId}.
      */
     @ResolveField(() => Production, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async production(@Context() ctx: { req: Request }, @Parent() credit: Credit): Promise<Production> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/group/group.resolver.ts
+++ b/src/types/group/group.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -19,6 +19,7 @@ import { OrderGroupPermissionInput } from "../group_permission/dto/order-group_p
 import { UserGroup } from "../user_group/user_group.entity";
 import { FilterUserGroupInput } from "../user_group/dto/filter-user_group.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Group)
 export class GroupResolver {
@@ -27,7 +28,7 @@ export class GroupResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Group], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Group)")
+    @Rule(RuleType.ReadMany, Group)
     async findManyGroup(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterGroupInput, nullable: true }) filter?: FilterGroupInput,
@@ -55,7 +56,7 @@ export class GroupResolver {
     }
 
     @Query(() => Group, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Group)")
+    @Rule(RuleType.ReadOne, Group)
     async findOneGroup(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -69,7 +70,7 @@ export class GroupResolver {
     }
 
     @Mutation(() => Group, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Group)")
+    @Rule(RuleType.Create, Group)
     async createGroup(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateGroupInput }) input: CreateGroupInput
@@ -97,7 +98,7 @@ export class GroupResolver {
     }
 
     @Mutation(() => Group, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Group)")
+    @Rule(RuleType.Update, Group)
     async updateGroup(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -149,7 +150,7 @@ export class GroupResolver {
     }
 
     @Mutation(() => Group, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Group)")
+    @Rule(RuleType.Delete, Group)
     async deleteGroup(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -190,7 +191,7 @@ export class GroupResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Group)")
+    @Rule(RuleType.Count, Group)
     async groupCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterGroupInput, nullable: true }) filter?: FilterGroupInput
@@ -208,7 +209,7 @@ export class GroupResolver {
      * Virtual field resolver for the Group corresponding to the Group's {@link Group#parentId}.
      */
     @ResolveField(() => Group, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Group)")
+    @Rule(RuleType.ReadOne, Group)
     async parent(@Context() ctx: { req: Request }, @Parent() group: Group): Promise<Group> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -225,7 +226,7 @@ export class GroupResolver {
      * Virtual field resolver for all GroupPermissions which have this Group as their {@link GroupPermission#groupId}.
      */
     @ResolveField(() => [GroupPermission], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: GroupPermission)")
+    @Rule(RuleType.ReadMany, GroupPermission)
     async permissions(
         @Context() ctx: { req: Request },
         @Parent() group: Group,
@@ -259,7 +260,7 @@ export class GroupResolver {
      * Virtual field resolver for all Groups which have this Group as their {@link Group#parentId}.
      */
     @ResolveField(() => [Group], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Group)")
+    @Rule(RuleType.ReadMany, Group)
     async children(
         @Context() ctx: { req: Request },
         @Parent() group: Group,
@@ -293,7 +294,7 @@ export class GroupResolver {
      * Virtual field resolver for all UserGroups which have this Group as their {@link UserGroup#groupId}.
      */
     @ResolveField(() => [UserGroup], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: UserGroup)")
+    @Rule(RuleType.ReadMany, UserGroup)
     async users(
         @Context() ctx: { req: Request },
         @Parent() group: Group,

--- a/src/types/group_permission/group_permission.resolver.ts
+++ b/src/types/group_permission/group_permission.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -15,6 +15,7 @@ import { CreateGroupPermissionInput } from "./dto/create-group_permission.input"
 import { UpdateGroupPermissionInput } from "./dto/update-group_permission.input";
 import { Group } from "../group/group.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => GroupPermission)
 export class GroupPermissionResolver {
@@ -23,7 +24,7 @@ export class GroupPermissionResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [GroupPermission], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: GroupPermission)")
+    @Rule(RuleType.ReadMany, GroupPermission)
     async findManyGroupPermission(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterGroupPermissionInput, nullable: true }) filter?: FilterGroupPermissionInput,
@@ -51,7 +52,7 @@ export class GroupPermissionResolver {
     }
 
     @Query(() => GroupPermission, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: GroupPermission)")
+    @Rule(RuleType.ReadOne, GroupPermission)
     async findOneGroupPermission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -65,7 +66,7 @@ export class GroupPermissionResolver {
     }
 
     @Mutation(() => GroupPermission, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: GroupPermission)")
+    @Rule(RuleType.Create, GroupPermission)
     async createGroupPermission(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateGroupPermissionInput }) input: CreateGroupPermissionInput
@@ -93,7 +94,7 @@ export class GroupPermissionResolver {
     }
 
     @Mutation(() => GroupPermission, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: GroupPermission)")
+    @Rule(RuleType.Update, GroupPermission)
     async updateGroupPermission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -145,7 +146,7 @@ export class GroupPermissionResolver {
     }
 
     @Mutation(() => GroupPermission, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: GroupPermission)")
+    @Rule(RuleType.Delete, GroupPermission)
     async deleteGroupPermission(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -186,7 +187,7 @@ export class GroupPermissionResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: GroupPermission)")
+    @Rule(RuleType.Count, GroupPermission)
     async groupPermissionCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterGroupPermissionInput, nullable: true }) filter?: FilterGroupPermissionInput
@@ -204,7 +205,7 @@ export class GroupPermissionResolver {
      * Virtual field resolver for the Group corresponding to the GroupPermission's {@link GroupPermission#groupId}.
      */
     @ResolveField(() => Group, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Group)")
+    @Rule(RuleType.ReadOne, Group)
     async group(@Context() ctx: { req: Request }, @Parent() groupPermission: GroupPermission): Promise<Group> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/image/image.resolver.ts
+++ b/src/types/image/image.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -25,6 +25,7 @@ import { FilterPersonInput } from "../person/dto/filter-person.input";
 import { OrderPersonInput } from "../person/dto/order-person.input";
 import { GraphQLBigInt } from "graphql-scalars";
 import { OrderProductionImageInput } from "../production_image/dto/order-production_image.input";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Image)
 export class ImageResolver {
@@ -33,7 +34,7 @@ export class ImageResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Image], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Image)")
+    @Rule(RuleType.ReadMany, Image)
     async findManyImage(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterImageInput, nullable: true }) filter?: FilterImageInput,
@@ -61,7 +62,7 @@ export class ImageResolver {
     }
 
     @Query(() => Image, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Image)")
+    @Rule(RuleType.ReadOne, Image)
     async findOneImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -75,7 +76,7 @@ export class ImageResolver {
     }
 
     @Mutation(() => Image, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Image)")
+    @Rule(RuleType.Create, Image)
     async createImage(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateImageInput }) input: CreateImageInput
@@ -103,7 +104,7 @@ export class ImageResolver {
     }
 
     @Mutation(() => Image, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Image)")
+    @Rule(RuleType.Update, Image)
     async updateImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -155,7 +156,7 @@ export class ImageResolver {
     }
 
     @Mutation(() => Image, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Image)")
+    @Rule(RuleType.Delete, Image)
     async deleteImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -196,7 +197,7 @@ export class ImageResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Image)")
+    @Rule(RuleType.Count, Image)
     async imageCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterImageInput, nullable: true }) filter?: FilterImageInput
@@ -214,7 +215,7 @@ export class ImageResolver {
      * Virtual field resolver for all PersonImages which have this Image as their {@link PersonImage#imageId}.
      */
     @ResolveField(() => [PersonImage], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: PersonImage)")
+    @Rule(RuleType.ReadMany, PersonImage)
     async people(
         @Context() ctx: { req: Request },
         @Parent() image: Image,
@@ -244,7 +245,7 @@ export class ImageResolver {
      * Virtual field resolver for all ProductionImages which have this Image as their {@link ProductionImage#imageId}.
      */
     @ResolveField(() => [ProductionImage], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionImage)")
+    @Rule(RuleType.ReadMany, ProductionImage)
     async productions(
         @Context() ctx: { req: Request },
         @Parent() image: Image,
@@ -278,7 +279,7 @@ export class ImageResolver {
      * Virtual field resolver for all Productions which have this Image as their {@link Production#thumbnailId}.
      */
     @ResolveField(() => [Production], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Production)")
+    @Rule(RuleType.ReadMany, Production)
     async thumbnailFor(
         @Context() ctx: { req: Request },
         @Parent() image: Image,
@@ -312,7 +313,7 @@ export class ImageResolver {
      * Virtual field resolver for all Persons which have this Image as their {@link Person#profilePictureId}.
      */
     @ResolveField(() => [Person], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Person)")
+    @Rule(RuleType.ReadMany, Person)
     async profilePictureFor(
         @Context() ctx: { req: Request },
         @Parent() image: Image,

--- a/src/types/person/person.resolver.ts
+++ b/src/types/person/person.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -28,7 +28,8 @@ import { User } from "../user/user.entity";
 import { FilterUserInput } from "../user/dto/filter-user.input";
 import { OrderUserInput } from "../user/dto/order-user.input";
 import { GraphQLBigInt } from "graphql-scalars";
-import {Image} from "../image/image.entity";
+import { Image } from "../image/image.entity";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Person)
 export class PersonResolver {
@@ -37,7 +38,7 @@ export class PersonResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Person], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Person)")
+    @Rule(RuleType.ReadMany, Person)
     async findManyPerson(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterPersonInput, nullable: true }) filter?: FilterPersonInput,
@@ -65,7 +66,7 @@ export class PersonResolver {
     }
 
     @Query(() => Person, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async findOnePerson(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -79,7 +80,7 @@ export class PersonResolver {
     }
 
     @Mutation(() => Person, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Person)")
+    @Rule(RuleType.Create, Person)
     async createPerson(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreatePersonInput }) input: CreatePersonInput
@@ -107,7 +108,7 @@ export class PersonResolver {
     }
 
     @Mutation(() => Person, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Person)")
+    @Rule(RuleType.Update, Person)
     async updatePerson(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -159,7 +160,7 @@ export class PersonResolver {
     }
 
     @Mutation(() => Person, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Person)")
+    @Rule(RuleType.Delete, Person)
     async deletePerson(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -200,7 +201,7 @@ export class PersonResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Person)")
+    @Rule(RuleType.Count, Person)
     async personCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterPersonInput, nullable: true }) filter?: FilterPersonInput
@@ -218,7 +219,7 @@ export class PersonResolver {
      * Virtual field resolver for all BlogPosts which have this Person as their {@link BlogPost#authorId}.
      */
     @ResolveField(() => [BlogPost], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: BlogPost)")
+    @Rule(RuleType.ReadMany, BlogPost)
     async blogPosts(
         @Context() ctx: { req: Request },
         @Parent() person: Person,
@@ -252,7 +253,7 @@ export class PersonResolver {
      * Virtual field resolver for all Credits which have this Person as their {@link Credit#personId}.
      */
     @ResolveField(() => [Credit], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Credit)")
+    @Rule(RuleType.ReadMany, Credit)
     async credits(
         @Context() ctx: { req: Request },
         @Parent() person: Person,
@@ -286,7 +287,7 @@ export class PersonResolver {
      * Virtual field resolver for all PersonImages which have this Person as their {@link PersonImage#personId}.
      */
     @ResolveField(() => [PersonImage], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: PersonImage)")
+    @Rule(RuleType.ReadMany, PersonImage)
     async images(
         @Context() ctx: { req: Request },
         @Parent() person: Person,
@@ -316,7 +317,7 @@ export class PersonResolver {
      * Virtual field resolver for all PersonRoles which have this Person as their {@link PersonRole#personId}.
      */
     @ResolveField(() => [PersonRole], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: PersonRole)")
+    @Rule(RuleType.ReadMany, PersonRole)
     async roles(
         @Context() ctx: { req: Request },
         @Parent() person: Person,
@@ -350,7 +351,7 @@ export class PersonResolver {
      * Virtual field resolver for all Users which have this Person as their {@link User#personId}.
      */
     @ResolveField(() => [User], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: User)")
+    @Rule(RuleType.ReadMany, User)
     async users(
         @Context() ctx: { req: Request },
         @Parent() person: Person,
@@ -384,7 +385,7 @@ export class PersonResolver {
      * Virtual field resolver for the Image corresponding to the Production's {@link Person#profilePictureId}.
      */
     @ResolveField(() => Image, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Image)")
+    @Rule(RuleType.ReadOne, Image)
     async profilePicture(@Context() ctx: { req: Request }, @Parent() person: Person): Promise<Image> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -397,6 +398,3 @@ export class PersonResolver {
         });
     }
 }
-
-
-

--- a/src/types/person_image/person_image.resolver.ts
+++ b/src/types/person_image/person_image.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { UpdatePersonImageInput } from "./dto/update-person_image.input";
 import { Person } from "../person/person.entity";
 import { Image } from "../image/image.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => PersonImage)
 export class PersonImageResolver {
@@ -22,7 +23,7 @@ export class PersonImageResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => PersonImage, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: PersonImage)")
+    @Rule(RuleType.ReadOne, PersonImage)
     async findOnePersonImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -36,7 +37,7 @@ export class PersonImageResolver {
     }
 
     @Mutation(() => PersonImage, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: PersonImage)")
+    @Rule(RuleType.Create, PersonImage)
     async createPersonImage(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreatePersonImageInput }) input: CreatePersonImageInput
@@ -64,7 +65,7 @@ export class PersonImageResolver {
     }
 
     @Mutation(() => PersonImage, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: PersonImage)")
+    @Rule(RuleType.Update, PersonImage)
     async updatePersonImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -116,7 +117,7 @@ export class PersonImageResolver {
     }
 
     @Mutation(() => PersonImage, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: PersonImage)")
+    @Rule(RuleType.Delete, PersonImage)
     async deletePersonImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -157,7 +158,7 @@ export class PersonImageResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: PersonImage)")
+    @Rule(RuleType.Count, PersonImage)
     async personImageCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterPersonImageInput, nullable: true }) filter?: FilterPersonImageInput
@@ -175,7 +176,7 @@ export class PersonImageResolver {
      * Virtual field resolver for the Person corresponding to the PersonImage's {@link PersonImage#personId}.
      */
     @ResolveField(() => Person, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async person(@Context() ctx: { req: Request }, @Parent() personImage: PersonImage): Promise<Person> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -192,7 +193,7 @@ export class PersonImageResolver {
      * Virtual field resolver for the Image corresponding to the PersonImage's {@link PersonImage#imageId}.
      */
     @ResolveField(() => Image, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Image)")
+    @Rule(RuleType.ReadOne, Image)
     async image(@Context() ctx: { req: Request }, @Parent() personImage: PersonImage): Promise<Image> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/person_role/person_role.resolver.ts
+++ b/src/types/person_role/person_role.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -16,6 +16,7 @@ import { UpdatePersonRoleInput } from "./dto/update-person_role.input";
 import { Person } from "../person/person.entity";
 import { Role } from "../role/role.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => PersonRole)
 export class PersonRoleResolver {
@@ -24,7 +25,7 @@ export class PersonRoleResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [PersonRole], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: PersonRole)")
+    @Rule(RuleType.ReadMany, PersonRole)
     async findManyPersonRole(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterPersonRoleInput, nullable: true }) filter?: FilterPersonRoleInput,
@@ -52,7 +53,7 @@ export class PersonRoleResolver {
     }
 
     @Query(() => PersonRole, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: PersonRole)")
+    @Rule(RuleType.ReadOne, PersonRole)
     async findOnePersonRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -66,7 +67,7 @@ export class PersonRoleResolver {
     }
 
     @Mutation(() => PersonRole, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: PersonRole)")
+    @Rule(RuleType.Create, PersonRole)
     async createPersonRole(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreatePersonRoleInput }) input: CreatePersonRoleInput
@@ -94,7 +95,7 @@ export class PersonRoleResolver {
     }
 
     @Mutation(() => PersonRole, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: PersonRole)")
+    @Rule(RuleType.Update, PersonRole)
     async updatePersonRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -146,7 +147,7 @@ export class PersonRoleResolver {
     }
 
     @Mutation(() => PersonRole, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: PersonRole)")
+    @Rule(RuleType.Delete, PersonRole)
     async deletePersonRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -187,7 +188,7 @@ export class PersonRoleResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: PersonRole)")
+    @Rule(RuleType.Count, PersonRole)
     async personRoleCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterPersonRoleInput, nullable: true }) filter?: FilterPersonRoleInput
@@ -205,7 +206,7 @@ export class PersonRoleResolver {
      * Virtual field resolver for the Person corresponding to the PersonRole's {@link PersonRole#personId}.
      */
     @ResolveField(() => Person, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async person(@Context() ctx: { req: Request }, @Parent() personRole: PersonRole): Promise<Person> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -222,7 +223,7 @@ export class PersonRoleResolver {
      * Virtual field resolver for the Role corresponding to the PersonRole's {@link PersonRole#roleId}.
      */
     @ResolveField(() => Role, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Role)")
+    @Rule(RuleType.ReadOne, Role)
     async role(@Context() ctx: { req: Request }, @Parent() personRole: PersonRole): Promise<Role> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/production/production.resolver.ts
+++ b/src/types/production/production.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -31,6 +31,7 @@ import { OrderProductionTagInput } from "../production_tag/dto/order-production_
 import { GraphQLBigInt } from "graphql-scalars";
 import { OrderProductionVideoInput } from "../production_video/dto/order-production_video.input";
 import { OrderProductionImageInput } from "../production_image/dto/order-production_image.input";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Production)
 export class ProductionResolver {
@@ -39,7 +40,7 @@ export class ProductionResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Production], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Production)")
+    @Rule(RuleType.ReadMany, Production)
     async findManyProduction(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionInput, nullable: true }) filter?: FilterProductionInput,
@@ -67,7 +68,7 @@ export class ProductionResolver {
     }
 
     @Query(() => Production, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async findOneProduction(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -81,7 +82,7 @@ export class ProductionResolver {
     }
 
     @Mutation(() => Production, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Production)")
+    @Rule(RuleType.Create, Production)
     async createProduction(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateProductionInput }) input: CreateProductionInput
@@ -109,7 +110,7 @@ export class ProductionResolver {
     }
 
     @Mutation(() => Production, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Production)")
+    @Rule(RuleType.Update, Production)
     async updateProduction(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -161,7 +162,7 @@ export class ProductionResolver {
     }
 
     @Mutation(() => Production, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Production)")
+    @Rule(RuleType.Delete, Production)
     async deleteProduction(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -202,7 +203,7 @@ export class ProductionResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Production)")
+    @Rule(RuleType.Count, Production)
     async productionCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionInput, nullable: true }) filter?: FilterProductionInput
@@ -220,7 +221,7 @@ export class ProductionResolver {
      * Virtual field resolver for the Category corresponding to the Production's {@link Production#categoryId}.
      */
     @ResolveField(() => Category, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Category)")
+    @Rule(RuleType.ReadOne, Category)
     async category(@Context() ctx: { req: Request }, @Parent() production: Production): Promise<Category> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -237,7 +238,7 @@ export class ProductionResolver {
      * Virtual field resolver for the Image corresponding to the Production's {@link Production#thumbnailId}.
      */
     @ResolveField(() => Image, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Image)")
+    @Rule(RuleType.ReadOne, Image)
     async thumbnail(@Context() ctx: { req: Request }, @Parent() production: Production): Promise<Image> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -254,7 +255,7 @@ export class ProductionResolver {
      * Virtual field resolver for all Credits which have this Production as their {@link Credit#productionId}.
      */
     @ResolveField(() => [Credit], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Credit)")
+    @Rule(RuleType.ReadMany, Credit)
     async credits(
         @Context() ctx: { req: Request },
         @Parent() production: Production,
@@ -288,7 +289,7 @@ export class ProductionResolver {
      * Virtual field resolver for all ProductionImages which have this Production as their {@link ProductionImage#productionId}.
      */
     @ResolveField(() => [ProductionImage], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionImage)")
+    @Rule(RuleType.ReadMany, ProductionImage)
     async images(
         @Context() ctx: { req: Request },
         @Parent() production: Production,
@@ -322,7 +323,7 @@ export class ProductionResolver {
      * Virtual field resolver for all ProductionVideos which have this Production as their {@link ProductionVideo#productionId}.
      */
     @ResolveField(() => [ProductionVideo], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionVideo)")
+    @Rule(RuleType.ReadMany, ProductionVideo)
     async videos(
         @Context() ctx: { req: Request },
         @Parent() production: Production,
@@ -356,7 +357,7 @@ export class ProductionResolver {
      * Virtual field resolver for all ProductionRSVPs which have this Production as their {@link ProductionRSVP#productionId}.
      */
     @ResolveField(() => [ProductionRSVP], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionRSVP)")
+    @Rule(RuleType.ReadMany, ProductionRSVP)
     async rsvps(
         @Context() ctx: { req: Request },
         @Parent() production: Production,
@@ -390,7 +391,7 @@ export class ProductionResolver {
      * Virtual field resolver for all ProductionTags which have this Production as their {@link ProductionTag#productionId}.
      */
     @ResolveField(() => [ProductionTag], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionTag)")
+    @Rule(RuleType.ReadMany, ProductionTag)
     async tags(
         @Context() ctx: { req: Request },
         @Parent() production: Production,

--- a/src/types/production_image/production_image.resolver.ts
+++ b/src/types/production_image/production_image.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { UpdateProductionImageInput } from "./dto/update-production_image.input"
 import { Production } from "../production/production.entity";
 import { Image } from "../image/image.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => ProductionImage)
 export class ProductionImageResolver {
@@ -22,7 +23,7 @@ export class ProductionImageResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => ProductionImage, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: ProductionImage)")
+    @Rule(RuleType.ReadOne, ProductionImage)
     async findOneProductionImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -36,7 +37,7 @@ export class ProductionImageResolver {
     }
 
     @Mutation(() => ProductionImage, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: ProductionImage)")
+    @Rule(RuleType.Create, ProductionImage)
     async createProductionImage(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateProductionImageInput }) input: CreateProductionImageInput
@@ -64,7 +65,7 @@ export class ProductionImageResolver {
     }
 
     @Mutation(() => ProductionImage, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: ProductionImage)")
+    @Rule(RuleType.Update, ProductionImage)
     async updateProductionImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -116,7 +117,7 @@ export class ProductionImageResolver {
     }
 
     @Mutation(() => ProductionImage, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: ProductionImage)")
+    @Rule(RuleType.Delete, ProductionImage)
     async deleteProductionImage(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -157,7 +158,7 @@ export class ProductionImageResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: ProductionImage)")
+    @Rule(RuleType.Count, ProductionImage)
     async productionImageCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionImageInput, nullable: true }) filter?: FilterProductionImageInput
@@ -175,7 +176,7 @@ export class ProductionImageResolver {
      * Virtual field resolver for the Production corresponding to the ProductionImage's {@link ProductionImage#productionId}.
      */
     @ResolveField(() => Production, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async production(
         @Context() ctx: { req: Request },
         @Parent() productionImage: ProductionImage
@@ -195,7 +196,7 @@ export class ProductionImageResolver {
      * Virtual field resolver for the Image corresponding to the ProductionImage's {@link ProductionImage#imageId}.
      */
     @ResolveField(() => Image, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Image)")
+    @Rule(RuleType.ReadOne, Image)
     async image(@Context() ctx: { req: Request }, @Parent() productionImage: ProductionImage): Promise<Image> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/production_rsvp/production_rsvp.resolver.ts
+++ b/src/types/production_rsvp/production_rsvp.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -16,6 +16,7 @@ import { UpdateProductionRSVPInput } from "./dto/update-production_rsvp.input";
 import { Production } from "../production/production.entity";
 import { User } from "../user/user.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => ProductionRSVP)
 export class ProductionRSVPResolver {
@@ -24,7 +25,7 @@ export class ProductionRSVPResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [ProductionRSVP], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionRSVP)")
+    @Rule(RuleType.ReadMany, ProductionRSVP)
     async findManyProductionRSVP(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionRSVPInput, nullable: true }) filter?: FilterProductionRSVPInput,
@@ -52,7 +53,7 @@ export class ProductionRSVPResolver {
     }
 
     @Query(() => ProductionRSVP, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: ProductionRSVP)")
+    @Rule(RuleType.ReadOne, ProductionRSVP)
     async findOneProductionRSVP(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -66,7 +67,7 @@ export class ProductionRSVPResolver {
     }
 
     @Mutation(() => ProductionRSVP, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: ProductionRSVP)")
+    @Rule(RuleType.Create, ProductionRSVP)
     async createProductionRSVP(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateProductionRSVPInput }) input: CreateProductionRSVPInput
@@ -94,7 +95,7 @@ export class ProductionRSVPResolver {
     }
 
     @Mutation(() => ProductionRSVP, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: ProductionRSVP)")
+    @Rule(RuleType.Update, ProductionRSVP)
     async updateProductionRSVP(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -146,7 +147,7 @@ export class ProductionRSVPResolver {
     }
 
     @Mutation(() => ProductionRSVP, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: ProductionRSVP)")
+    @Rule(RuleType.Delete, ProductionRSVP)
     async deleteProductionRSVP(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -187,7 +188,7 @@ export class ProductionRSVPResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: ProductionRSVP)")
+    @Rule(RuleType.Count, ProductionRSVP)
     async productionRSVPCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionRSVPInput, nullable: true }) filter?: FilterProductionRSVPInput
@@ -205,7 +206,7 @@ export class ProductionRSVPResolver {
      * Virtual field resolver for the Production corresponding to the ProductionRSVP's {@link ProductionRSVP#productionId}.
      */
     @ResolveField(() => Production, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async production(@Context() ctx: { req: Request }, @Parent() productionRSVP: ProductionRSVP): Promise<Production> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -222,7 +223,7 @@ export class ProductionRSVPResolver {
      * Virtual field resolver for the User corresponding to the ProductionRSVP's {@link ProductionRSVP#userId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async user(@Context() ctx: { req: Request }, @Parent() productionRSVP: ProductionRSVP): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/production_tag/production_tag.resolver.ts
+++ b/src/types/production_tag/production_tag.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { OrderProductionTagInput } from "./dto/order-production_tag.input";
 import { CreateProductionTagInput } from "./dto/create-production_tag.input";
 import { Production } from "../production/production.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => ProductionTag)
 export class ProductionTagResolver {
@@ -22,7 +23,7 @@ export class ProductionTagResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [ProductionTag], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionTag)")
+    @Rule(RuleType.ReadMany, ProductionTag)
     async findManyProductionTag(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionTagInput, nullable: true }) filter?: FilterProductionTagInput,
@@ -50,7 +51,7 @@ export class ProductionTagResolver {
     }
 
     @Query(() => ProductionTag, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: ProductionTag)")
+    @Rule(RuleType.ReadOne, ProductionTag)
     async findOneProductionTag(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -64,7 +65,7 @@ export class ProductionTagResolver {
     }
 
     @Mutation(() => ProductionTag, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: ProductionTag)")
+    @Rule(RuleType.Create, ProductionTag)
     async createProductionTag(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateProductionTagInput }) input: CreateProductionTagInput
@@ -92,7 +93,7 @@ export class ProductionTagResolver {
     }
 
     @Mutation(() => ProductionTag, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: ProductionTag)")
+    @Rule(RuleType.Delete, ProductionTag)
     async deleteProductionTag(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -133,7 +134,7 @@ export class ProductionTagResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: ProductionTag)")
+    @Rule(RuleType.Count, ProductionTag)
     async productionTagCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionTagInput, nullable: true }) filter?: FilterProductionTagInput
@@ -151,7 +152,7 @@ export class ProductionTagResolver {
      * Virtual field resolver for the Production corresponding to the ProductionTag's {@link ProductionTag#productionId}.
      */
     @ResolveField(() => Production, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async production(@Context() ctx: { req: Request }, @Parent() productionTag: ProductionTag): Promise<Production> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/production_video/production_video.resolver.ts
+++ b/src/types/production_video/production_video.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { UpdateProductionVideoInput } from "./dto/update-production_video.input"
 import { Production } from "../production/production.entity";
 import { Video } from "../video/video.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => ProductionVideo)
 export class ProductionVideoResolver {
@@ -22,7 +23,7 @@ export class ProductionVideoResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => ProductionVideo, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: ProductionVideo)")
+    @Rule(RuleType.ReadOne, ProductionVideo)
     async findOneProductionVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -36,7 +37,7 @@ export class ProductionVideoResolver {
     }
 
     @Mutation(() => ProductionVideo, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: ProductionVideo)")
+    @Rule(RuleType.Create, ProductionVideo)
     async createProductionVideo(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateProductionVideoInput }) input: CreateProductionVideoInput
@@ -64,7 +65,7 @@ export class ProductionVideoResolver {
     }
 
     @Mutation(() => ProductionVideo, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: ProductionVideo)")
+    @Rule(RuleType.Update, ProductionVideo)
     async updateProductionVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -116,7 +117,7 @@ export class ProductionVideoResolver {
     }
 
     @Mutation(() => ProductionVideo, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: ProductionVideo)")
+    @Rule(RuleType.Delete, ProductionVideo)
     async deleteProductionVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -157,7 +158,7 @@ export class ProductionVideoResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: ProductionVideo)")
+    @Rule(RuleType.Count, ProductionVideo)
     async productionVideoCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterProductionVideoInput, nullable: true }) filter?: FilterProductionVideoInput
@@ -175,7 +176,7 @@ export class ProductionVideoResolver {
      * Virtual field resolver for the Production corresponding to the ProductionVideo's {@link ProductionVideo#productionId}.
      */
     @ResolveField(() => Production, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Production)")
+    @Rule(RuleType.ReadOne, Production)
     async production(
         @Context() ctx: { req: Request },
         @Parent() productionVideo: ProductionVideo
@@ -195,7 +196,7 @@ export class ProductionVideoResolver {
      * Virtual field resolver for the Video corresponding to the ProductionVideo's {@link ProductionVideo#videoId}.
      */
     @ResolveField(() => Video, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Video)")
+    @Rule(RuleType.ReadOne, Video)
     async video(@Context() ctx: { req: Request }, @Parent() productionVideo: ProductionVideo): Promise<Video> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/redirect/redirect.resolver.ts
+++ b/src/types/redirect/redirect.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { OrderRedirectInput } from "./dto/order-redirect.input";
 import { CreateRedirectInput } from "./dto/create-redirect.input";
 import { UpdateRedirectInput } from "./dto/update-redirect.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Redirect)
 export class RedirectResolver {
@@ -22,7 +23,7 @@ export class RedirectResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Redirect], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Redirect)")
+    @Rule(RuleType.ReadMany, Redirect)
     async findManyRedirect(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterRedirectInput, nullable: true }) filter?: FilterRedirectInput,
@@ -50,7 +51,7 @@ export class RedirectResolver {
     }
 
     @Query(() => Redirect, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Redirect)")
+    @Rule(RuleType.ReadOne, Redirect)
     async findOneRedirect(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -64,7 +65,7 @@ export class RedirectResolver {
     }
 
     @Mutation(() => Redirect, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Redirect)")
+    @Rule(RuleType.Create, Redirect)
     async createRedirect(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateRedirectInput }) input: CreateRedirectInput
@@ -92,7 +93,7 @@ export class RedirectResolver {
     }
 
     @Mutation(() => Redirect, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Redirect)")
+    @Rule(RuleType.Update, Redirect)
     async updateRedirect(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -144,7 +145,7 @@ export class RedirectResolver {
     }
 
     @Mutation(() => Redirect, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Redirect)")
+    @Rule(RuleType.Delete, Redirect)
     async deleteRedirect(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -185,7 +186,7 @@ export class RedirectResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Redirect)")
+    @Rule(RuleType.Count, Redirect)
     async redirectCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterRedirectInput, nullable: true }) filter?: FilterRedirectInput

--- a/src/types/role/role.resolver.ts
+++ b/src/types/role/role.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -17,6 +17,7 @@ import { PersonRole } from "../person_role/person_role.entity";
 import { FilterPersonRoleInput } from "../person_role/dto/filter-person_role.input";
 import { OrderPersonRoleInput } from "../person_role/dto/order-person_role.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Role)
 export class RoleResolver {
@@ -25,7 +26,7 @@ export class RoleResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Role], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Role)")
+    @Rule(RuleType.ReadMany, Role)
     async findManyRole(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterRoleInput, nullable: true }) filter?: FilterRoleInput,
@@ -53,7 +54,7 @@ export class RoleResolver {
     }
 
     @Query(() => Role, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Role)")
+    @Rule(RuleType.ReadOne, Role)
     async findOneRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -67,7 +68,7 @@ export class RoleResolver {
     }
 
     @Mutation(() => Role, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Role)")
+    @Rule(RuleType.Create, Role)
     async createRole(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateRoleInput }) input: CreateRoleInput
@@ -95,7 +96,7 @@ export class RoleResolver {
     }
 
     @Mutation(() => Role, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Role)")
+    @Rule(RuleType.Update, Role)
     async updateRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -147,7 +148,7 @@ export class RoleResolver {
     }
 
     @Mutation(() => Role, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Role)")
+    @Rule(RuleType.Delete, Role)
     async deleteRole(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -188,7 +189,7 @@ export class RoleResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Role)")
+    @Rule(RuleType.Count, Role)
     async roleCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterRoleInput, nullable: true }) filter?: FilterRoleInput
@@ -206,7 +207,7 @@ export class RoleResolver {
      * Virtual field resolver for all PersonRoles which have this Role as their {@link PersonRole#roleId}.
      */
     @ResolveField(() => [PersonRole], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: PersonRole)")
+    @Rule(RuleType.ReadMany, PersonRole)
     async people(
         @Context() ctx: { req: Request },
         @Parent() role: Role,

--- a/src/types/stream/stream.resolver.ts
+++ b/src/types/stream/stream.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -12,6 +12,7 @@ import { CreateStreamInput } from "./dto/create-stream.input";
 import { connect, Connection, ConsumeMessage } from "amqplib";
 import { GraphQLUUID } from "graphql-scalars";
 import { ConfigService } from "@nestjs/config";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Stream)
 export class StreamResolver {
@@ -95,7 +96,7 @@ export class StreamResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Stream], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Stream)")
+    @Rule(RuleType.ReadMany, Stream)
     async findManyStream(
         @Context() ctx: { req: Request },
         @Args("pagination", { type: () => PaginationInput, nullable: true }) pagination?: PaginationInput
@@ -113,7 +114,7 @@ export class StreamResolver {
     }
 
     @Query(() => Stream, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Stream)")
+    @Rule(RuleType.ReadOne, Stream)
     async findOneStream(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLUUID }) id: string
@@ -123,7 +124,7 @@ export class StreamResolver {
     }
 
     @Mutation(() => Stream, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Stream)")
+    @Rule(RuleType.Create, Stream)
     async createStream(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateStreamInput }) input: CreateStreamInput
@@ -157,7 +158,7 @@ export class StreamResolver {
     }
 
     @Mutation(() => Stream, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Stream)")
+    @Rule(RuleType.Delete, Stream)
     async deleteStream(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLUUID }) id: string
@@ -191,7 +192,7 @@ export class StreamResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Stream)")
+    @Rule(RuleType.Count, Stream)
     async streamCount(): Promise<number> {
         return this.streams.length;
     }

--- a/src/types/user/user.resolver.ts
+++ b/src/types/user/user.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { User } from "./user.entity";
 import { CreateUserInput } from "./dto/create-user.input";
 import { UpdateUserInput } from "./dto/update-user.input";
@@ -36,6 +36,7 @@ import { VoteResponse } from "../vote_response/vote_response.entity";
 import { FilterVoteResponseInput } from "../vote_response/dto/filter-vote_response.input";
 import { OrderVoteResponseInput } from "../vote_response/dto/order-vote_response.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => User)
 export class UserResolver {
@@ -46,7 +47,7 @@ export class UserResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [User], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: User)")
+    @Rule(RuleType.ReadMany, User)
     async findManyUser(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterUserInput, nullable: true }) filter?: FilterUserInput,
@@ -74,7 +75,7 @@ export class UserResolver {
     }
 
     @Query(() => User, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async findOneUser(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -88,7 +89,7 @@ export class UserResolver {
     }
 
     @Mutation(() => User, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: User)")
+    @Rule(RuleType.Create, User)
     async createUser(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateUserInput }) input: CreateUserInput
@@ -121,7 +122,7 @@ export class UserResolver {
     }
 
     @Mutation(() => User, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: User)")
+    @Rule(RuleType.Update, User)
     async updateUser(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -178,7 +179,7 @@ export class UserResolver {
     }
 
     @Mutation(() => User, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: User)")
+    @Rule(RuleType.Delete, User)
     async deleteUser(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -219,7 +220,7 @@ export class UserResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: User)")
+    @Rule(RuleType.Count, User)
     async userCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterUserInput, nullable: true }) filter?: FilterUserInput
@@ -237,7 +238,7 @@ export class UserResolver {
      * Virtual field resolver for the Person corresponding to the User's {@link User#personId}.
      */
     @ResolveField(() => Person, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Person)")
+    @Rule(RuleType.ReadOne, Person)
     async person(@Context() ctx: { req: Request }, @Parent() user: User): Promise<Person> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -254,7 +255,7 @@ export class UserResolver {
      * Virtual field resolver for all AccessLogs which have this User as their {@link AccessLog#userId}.
      */
     @ResolveField(() => [AccessLog], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: AccessLog)")
+    @Rule(RuleType.ReadMany, AccessLog)
     async accessLogs(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -288,7 +289,7 @@ export class UserResolver {
      * Virtual field resolver for all Assets which have this User as their {@link Asset#lastKnownHandlerId}.
      */
     @ResolveField(() => [Asset], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: Asset)")
+    @Rule(RuleType.ReadMany, Asset)
     async checkedOutAssets(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -322,7 +323,7 @@ export class UserResolver {
      * Virtual field resolver for all AuditLogs which have this User as their {@link AuditLog#userId}.
      */
     @ResolveField(() => [AuditLog], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: AuditLog)")
+    @Rule(RuleType.ReadMany, AuditLog)
     async auditLogs(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -356,7 +357,7 @@ export class UserResolver {
      * Virtual field resolver for all ProductionRSVPs which have this User as their {@link ProductionRSVP#userId}.
      */
     @ResolveField(() => [ProductionRSVP], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionRSVP)")
+    @Rule(RuleType.ReadMany, ProductionRSVP)
     async productionRsvps(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -390,7 +391,7 @@ export class UserResolver {
      * Virtual field resolver for all UserGroups which have this User as their {@link UserGroup#userId}.
      */
     @ResolveField(() => [UserGroup], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: UserGroup)")
+    @Rule(RuleType.ReadMany, UserGroup)
     async groups(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -422,7 +423,7 @@ export class UserResolver {
      *  Query.permissionsFor resolver.
      */
     @ResolveField(() => [UserPermission], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: UserPermission)")
+    @Rule(RuleType.ReadMany, UserPermission)
     async permissions(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -456,7 +457,7 @@ export class UserResolver {
      * Virtual field resolver for all VoteResponses which have this User as their {@link VoteResponse#userId}.
      */
     @ResolveField(() => [VoteResponse], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: VoteResponse)")
+    @Rule(RuleType.ReadMany, VoteResponse)
     async voteResponses(
         @Context() ctx: { req: Request },
         @Parent() user: User,
@@ -489,7 +490,7 @@ export class UserResolver {
     // -------------------- Custom Resolvers --------------------
 
     @Query(() => User, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive('@rule(ruleType: ReadOne, subject: User, options: { name: "Read self", defer: true })')
+    @Rule(RuleType.ReadOne, User, { name: "Read self", defer: true })
     async self(@Session() session: Record<string, any>, @Context() ctx: any): Promise<User | null> {
         this.logger.verbose("self resolver called");
         return ctx.req.user || null;

--- a/src/types/user_group/user_group.resolver.ts
+++ b/src/types/user_group/user_group.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -13,6 +13,7 @@ import { CreateUserGroupInput } from "./dto/create-user_group.input";
 import { User } from "../user/user.entity";
 import { Group } from "../group/group.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => UserGroup)
 export class UserGroupResolver {
@@ -21,7 +22,7 @@ export class UserGroupResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => UserGroup, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: UserGroup)")
+    @Rule(RuleType.ReadOne, UserGroup)
     async findOneUserGroup(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -35,7 +36,7 @@ export class UserGroupResolver {
     }
 
     @Mutation(() => UserGroup, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: UserGroup)")
+    @Rule(RuleType.Create, UserGroup)
     async createUserGroup(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateUserGroupInput }) input: CreateUserGroupInput
@@ -63,7 +64,7 @@ export class UserGroupResolver {
     }
 
     @Mutation(() => UserGroup, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: UserGroup)")
+    @Rule(RuleType.Delete, UserGroup)
     async deleteUserGroup(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -104,7 +105,7 @@ export class UserGroupResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: UserGroup)")
+    @Rule(RuleType.Count, UserGroup)
     async userGroupCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterUserGroupInput, nullable: true }) filter?: FilterUserGroupInput
@@ -122,7 +123,7 @@ export class UserGroupResolver {
      * Virtual field resolver for the User corresponding to the UserGroup's {@link UserGroup#userId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async user(@Context() ctx: { req: Request }, @Parent() userGroup: UserGroup): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -139,7 +140,7 @@ export class UserGroupResolver {
      * Virtual field resolver for the Group corresponding to the UserGroup's {@link UserGroup#groupId}.
      */
     @ResolveField(() => Group, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Group)")
+    @Rule(RuleType.ReadOne, Group)
     async group(@Context() ctx: { req: Request }, @Parent() userGroup: UserGroup): Promise<Group> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.

--- a/src/types/video/video.resolver.ts
+++ b/src/types/video/video.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -17,6 +17,7 @@ import { ProductionVideo } from "../production_video/production_video.entity";
 import { FilterProductionVideoInput } from "../production_video/dto/filter-production_video.input";
 import { GraphQLBigInt } from "graphql-scalars";
 import { OrderProductionVideoInput } from "../production_video/dto/order-production_video.input";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Video)
 export class VideoResolver {
@@ -25,7 +26,7 @@ export class VideoResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Video], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Video)")
+    @Rule(RuleType.ReadMany, Video)
     async findManyVideo(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVideoInput, nullable: true }) filter?: FilterVideoInput,
@@ -53,7 +54,7 @@ export class VideoResolver {
     }
 
     @Query(() => Video, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Video)")
+    @Rule(RuleType.ReadOne, Video)
     async findOneVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -67,7 +68,7 @@ export class VideoResolver {
     }
 
     @Mutation(() => Video, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Video)")
+    @Rule(RuleType.Create, Video)
     async createVideo(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateVideoInput }) input: CreateVideoInput
@@ -95,7 +96,7 @@ export class VideoResolver {
     }
 
     @Mutation(() => Video, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Video)")
+    @Rule(RuleType.Update, Video)
     async updateVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -147,7 +148,7 @@ export class VideoResolver {
     }
 
     @Mutation(() => Video, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Video)")
+    @Rule(RuleType.Delete, Video)
     async deleteVideo(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -188,7 +189,7 @@ export class VideoResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Video)")
+    @Rule(RuleType.Count, Video)
     async videoCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVideoInput, nullable: true }) filter?: FilterVideoInput
@@ -206,7 +207,7 @@ export class VideoResolver {
      * Virtual field resolver for all ProductionVideos which have this Video as their {@link ProductionVideo#videoId}.
      */
     @ResolveField(() => [ProductionVideo], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: ProductionVideo)")
+    @Rule(RuleType.ReadMany, ProductionVideo)
     async productions(
         @Context() ctx: { req: Request },
         @Parent() video: Video,

--- a/src/types/vote/vote.resolver.ts
+++ b/src/types/vote/vote.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -17,6 +17,7 @@ import { VoteResponse } from "../vote_response/vote_response.entity";
 import { FilterVoteResponseInput } from "../vote_response/dto/filter-vote_response.input";
 import { OrderVoteResponseInput } from "../vote_response/dto/order-vote_response.input";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => Vote)
 export class VoteResolver {
@@ -25,7 +26,7 @@ export class VoteResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [Vote], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: Vote)")
+    @Rule(RuleType.ReadMany, Vote)
     async findManyVote(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVoteInput, nullable: true }) filter?: FilterVoteInput,
@@ -53,7 +54,7 @@ export class VoteResolver {
     }
 
     @Query(() => Vote, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: Vote)")
+    @Rule(RuleType.ReadOne, Vote)
     async findOneVote(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -67,7 +68,7 @@ export class VoteResolver {
     }
 
     @Mutation(() => Vote, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: Vote)")
+    @Rule(RuleType.Create, Vote)
     async createVote(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateVoteInput }) input: CreateVoteInput
@@ -95,7 +96,7 @@ export class VoteResolver {
     }
 
     @Mutation(() => Vote, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: Vote)")
+    @Rule(RuleType.Update, Vote)
     async updateVote(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -147,7 +148,7 @@ export class VoteResolver {
     }
 
     @Mutation(() => Vote, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: Vote)")
+    @Rule(RuleType.Delete, Vote)
     async deleteVote(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -188,7 +189,7 @@ export class VoteResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: Vote)")
+    @Rule(RuleType.Count, Vote)
     async voteCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVoteInput, nullable: true }) filter?: FilterVoteInput
@@ -206,7 +207,7 @@ export class VoteResolver {
      * Virtual field resolver for all VoteResponses which have this Vote as their {@link VoteResponse#voteId}.
      */
     @ResolveField(() => [VoteResponse], { nullable: true })
-    @Directive("@rule(ruleType: ReadMany, subject: VoteResponse)")
+    @Rule(RuleType.ReadMany, VoteResponse)
     async responses(
         @Context() ctx: { req: Request },
         @Parent() vote: Vote,

--- a/src/types/vote_response/vote_response.resolver.ts
+++ b/src/types/vote_response/vote_response.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Context, Directive, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { validate } from "class-validator";
 import { plainToClass } from "class-transformer";
 import { BadRequestException, Logger } from "@nestjs/common";
@@ -16,6 +16,7 @@ import { UpdateVoteResponseInput } from "./dto/update-vote_response.input";
 import { User } from "../user/user.entity";
 import { Vote } from "../vote/vote.entity";
 import { GraphQLBigInt } from "graphql-scalars";
+import { Rule, RuleType } from "../../casl/rule.decorator";
 
 @Resolver(() => VoteResponse)
 export class VoteResponseResolver {
@@ -24,7 +25,7 @@ export class VoteResponseResolver {
     // -------------------- Generic Resolvers --------------------
 
     @Query(() => [VoteResponse], { complexity: Complexities.ReadMany })
-    @Directive("@rule(ruleType: ReadMany, subject: VoteResponse)")
+    @Rule(RuleType.ReadMany, VoteResponse)
     async findManyVoteResponse(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVoteResponseInput, nullable: true }) filter?: FilterVoteResponseInput,
@@ -52,7 +53,7 @@ export class VoteResponseResolver {
     }
 
     @Query(() => VoteResponse, { nullable: true, complexity: Complexities.ReadOne })
-    @Directive("@rule(ruleType: ReadOne, subject: VoteResponse)")
+    @Rule(RuleType.ReadOne, VoteResponse)
     async findOneVoteResponse(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -66,7 +67,7 @@ export class VoteResponseResolver {
     }
 
     @Mutation(() => VoteResponse, { complexity: Complexities.Create })
-    @Directive("@rule(ruleType: Create, subject: VoteResponse)")
+    @Rule(RuleType.Create, VoteResponse)
     async createVoteResponse(
         @Context() ctx: { req: Request },
         @Args("input", { type: () => CreateVoteResponseInput }) input: CreateVoteResponseInput
@@ -94,7 +95,7 @@ export class VoteResponseResolver {
     }
 
     @Mutation(() => VoteResponse, { complexity: Complexities.Update })
-    @Directive("@rule(ruleType: Update, subject: VoteResponse)")
+    @Rule(RuleType.Update, VoteResponse)
     async updateVoteResponse(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint,
@@ -146,7 +147,7 @@ export class VoteResponseResolver {
     }
 
     @Mutation(() => VoteResponse, { complexity: Complexities.Delete })
-    @Directive("@rule(ruleType: Delete, subject: VoteResponse)")
+    @Rule(RuleType.Delete, VoteResponse)
     async deleteVoteResponse(
         @Context() ctx: { req: Request },
         @Args("id", { type: () => GraphQLBigInt }) id: bigint
@@ -187,7 +188,7 @@ export class VoteResponseResolver {
     }
 
     @Query(() => Int, { complexity: Complexities.Count })
-    @Directive("@rule(ruleType: Count, subject: VoteResponse)")
+    @Rule(RuleType.Count, VoteResponse)
     async voteResponseCount(
         @Context() ctx: { req: Request },
         @Args("filter", { type: () => FilterVoteResponseInput, nullable: true }) filter?: FilterVoteResponseInput
@@ -205,7 +206,7 @@ export class VoteResponseResolver {
      * Virtual field resolver for the User corresponding to the VoteResponse's {@link VoteResponse#userId}.
      */
     @ResolveField(() => User, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: User)")
+    @Rule(RuleType.ReadOne, User)
     async user(@Context() ctx: { req: Request }, @Parent() voteResponse: VoteResponse): Promise<User> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.
@@ -222,7 +223,7 @@ export class VoteResponseResolver {
      * Virtual field resolver for the Vote corresponding to the VoteResponse's {@link VoteResponse#voteId}.
      */
     @ResolveField(() => Vote, { nullable: true })
-    @Directive("@rule(ruleType: ReadOne, subject: Vote)")
+    @Rule(RuleType.ReadOne, Vote)
     async vote(@Context() ctx: { req: Request }, @Parent() voteResponse: VoteResponse): Promise<Vote> {
         // If this property is null, then the parent resolver explicitly set it to null because the user didn't have
         //  permission to read it, and strict mode was disabled. This is only guaranteed true for relational fields.


### PR DESCRIPTION
Refactoring to the `@Rule` decorator to be a wrapper around the GraphQL `@rule` directive. Also further abstracts the difference between "built-in" rule handlers and "custom" rule handlers. HTTP support is removed since it was untested and not used.