### PR TITLE
Add relation constraints

### DIFF
--- a/prisma/migrations/20230315183454_add_relational_actions/migration.sql
+++ b/prisma/migrations/20230315183454_add_relational_actions/migration.sql
@@ -1,0 +1,170 @@
+-- DropForeignKey
+ALTER TABLE "assets" DROP CONSTRAINT "assets_assets_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "assets" DROP CONSTRAINT "assets_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "audit_logs" DROP CONSTRAINT "audit_logs_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "blog_posts" DROP CONSTRAINT "blog_people_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "categories" DROP CONSTRAINT "categories_categories_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "credits" DROP CONSTRAINT "credits_people_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "credits" DROP CONSTRAINT "credits_productions_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "group_permissions" DROP CONSTRAINT "group_permissions_groups_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "groups" DROP CONSTRAINT "groups_groups_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "people_images" DROP CONSTRAINT "people_images_images_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "people_images" DROP CONSTRAINT "people_images_people_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "people_roles" DROP CONSTRAINT "people_roles_people_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "people_roles" DROP CONSTRAINT "people_roles_roles_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_images" DROP CONSTRAINT "production_images_images_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_images" DROP CONSTRAINT "production_images_productions_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_rsvps" DROP CONSTRAINT "production_rsvps_productions_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_rsvps" DROP CONSTRAINT "production_rsvps_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_tags" DROP CONSTRAINT "production_tags_productions_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_videos" DROP CONSTRAINT "production_videos_productions_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "production_videos" DROP CONSTRAINT "production_videos_videos_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "productions" DROP CONSTRAINT "productions_categories_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "productions" DROP CONSTRAINT "productions_images_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "user_groups" DROP CONSTRAINT "user_groups_groups_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "user_groups" DROP CONSTRAINT "user_groups_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "user_permissions" DROP CONSTRAINT "user_permissions_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_people_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "vote_responses" DROP CONSTRAINT "vote_responses_users_id_fk";
+
+-- DropForeignKey
+ALTER TABLE "vote_responses" DROP CONSTRAINT "vote_responses_votes_id_fk";
+
+-- AlterTable
+ALTER TABLE "blog_posts" ALTER COLUMN "author" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "assets" ADD CONSTRAINT "assets_users_id_fk" FOREIGN KEY ("last_known_handler") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "assets" ADD CONSTRAINT "assets_assets_id_fk" FOREIGN KEY ("parent") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_users_id_fk" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blog_posts" ADD CONSTRAINT "blog_people_id_fk" FOREIGN KEY ("author") REFERENCES "people"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "categories" ADD CONSTRAINT "categories_categories_id_fk" FOREIGN KEY ("parent") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "credits" ADD CONSTRAINT "credits_people_id_fk" FOREIGN KEY ("person") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "credits" ADD CONSTRAINT "credits_productions_id_fk" FOREIGN KEY ("production") REFERENCES "productions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "groups" ADD CONSTRAINT "groups_groups_id_fk" FOREIGN KEY ("parent") REFERENCES "groups"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_permissions" ADD CONSTRAINT "group_permissions_groups_id_fk" FOREIGN KEY ("group") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "people_images" ADD CONSTRAINT "people_images_images_id_fk" FOREIGN KEY ("image") REFERENCES "images"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "people_images" ADD CONSTRAINT "people_images_people_id_fk" FOREIGN KEY ("person") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "people_roles" ADD CONSTRAINT "people_roles_people_id_fk" FOREIGN KEY ("person") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "people_roles" ADD CONSTRAINT "people_roles_roles_id_fk" FOREIGN KEY ("role") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "productions" ADD CONSTRAINT "productions_categories_id_fk" FOREIGN KEY ("category") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "productions" ADD CONSTRAINT "productions_images_id_fk" FOREIGN KEY ("thumbnail") REFERENCES "images"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_images" ADD CONSTRAINT "production_images_images_id_fk" FOREIGN KEY ("image") REFERENCES "images"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_images" ADD CONSTRAINT "production_images_productions_id_fk" FOREIGN KEY ("production") REFERENCES "productions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_rsvps" ADD CONSTRAINT "production_rsvps_productions_id_fk" FOREIGN KEY ("production") REFERENCES "productions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_rsvps" ADD CONSTRAINT "production_rsvps_users_id_fk" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_tags" ADD CONSTRAINT "production_tags_productions_id_fk" FOREIGN KEY ("production") REFERENCES "productions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_videos" ADD CONSTRAINT "production_videos_productions_id_fk" FOREIGN KEY ("production") REFERENCES "productions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "production_videos" ADD CONSTRAINT "production_videos_videos_id_fk" FOREIGN KEY ("video") REFERENCES "videos"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_people_id_fk" FOREIGN KEY ("person") REFERENCES "people"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_groups" ADD CONSTRAINT "user_groups_groups_id_fk" FOREIGN KEY ("group") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_groups" ADD CONSTRAINT "user_groups_users_id_fk" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_users_id_fk" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "vote_responses" ADD CONSTRAINT "vote_responses_users_id_fk" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "vote_responses" ADD CONSTRAINT "vote_responses_votes_id_fk" FOREIGN KEY ("vote") REFERENCES "votes"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["clientExtensions"]
 }
 
@@ -9,11 +9,11 @@ datasource db {
 }
 
 model AccessLog {
-  userId    BigInt   @db.BigInt @map("user")
+  userId    BigInt   @map("user") @db.BigInt
   service   String   @db.VarChar(100)
   timestamp DateTime @default(now()) @db.Timestamp(6)
   ip        String?  @db.VarChar(60)
-  id        BigInt   @db.BigInt @id(map: "access_logs_pk") @default(autoincrement())
+  id        BigInt   @id(map: "access_logs_pk") @default(autoincrement()) @db.BigInt
   user      User     @relation(fields: [userId], references: [id], map: "access_logs_users_id_fk")
 
   @@index([userId, timestamp], map: "access_logs_userId_timestamp_index")
@@ -22,7 +22,7 @@ model AccessLog {
 }
 
 model AlertLog {
-  id        BigInt   @db.BigInt @id(map: "alert_logs_pk") @default(autoincrement())
+  id        BigInt   @id(map: "alert_logs_pk") @default(autoincrement()) @db.BigInt
   message   String   @db.VarChar(300)
   severity  String   @db.VarChar(8)
   timestamp DateTime @default(now()) @db.Timestamp(6)
@@ -33,11 +33,11 @@ model AlertLog {
 }
 
 model Asset {
-  id                 BigInt    @db.BigInt @id(map: "assets_pk") @default(autoincrement())
+  id                 BigInt    @id(map: "assets_pk") @default(autoincrement()) @db.BigInt
   tag                Int?
   name               String    @db.VarChar(150)
   lastKnownLocation  String?   @map("last_known_location") @db.VarChar(100)
-  lastKnownHandlerId BigInt?   @db.BigInt @map("last_known_handler")
+  lastKnownHandlerId BigInt?   @map("last_known_handler") @db.BigInt
   isLost             Boolean   @default(false) @map("is_lost")
   notes              String?   @db.VarChar(500)
   purchasePrice      Int?      @map("purchase_price")
@@ -45,9 +45,9 @@ model Asset {
   purchaseDate       DateTime? @map("purchase_date") @db.Date
   modelNumber        String?   @map("model_number") @db.VarChar(100)
   serialNumber       String?   @map("serial_number") @db.VarChar(100)
-  parentId           BigInt?   @db.BigInt @map("parent")
-  lastKnownHandler   User?     @relation("assetsTousers", fields: [lastKnownHandlerId], references: [id], onDelete: Restrict, map: "assets_users_id_fk")
-  parent             Asset?    @relation("assetsToassets_parent", fields: [parentId], references: [id], onDelete: Restrict, map: "assets_assets_id_fk")
+  parentId           BigInt?   @map("parent") @db.BigInt
+  lastKnownHandler   User?     @relation("assetsTousers", fields: [lastKnownHandlerId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "assets_users_id_fk")
+  parent             Asset?    @relation("assetsToassets_parent", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "assets_assets_id_fk")
   children           Asset[]   @relation("assetsToassets_parent")
 
   @@index([lastKnownHandlerId, tag], map: "assets_last_known_handler_tag_index")
@@ -60,15 +60,15 @@ model Asset {
 }
 
 model AuditLog {
-  id               BigInt   @db.BigInt @id(map: "audit_logs_pk") @default(autoincrement())
-  message          String?  @db.VarChar(300)
-  userId           BigInt?  @db.BigInt @map("user")
-  timestamp        DateTime @default(now()) @db.Timestamp(6)
-  subject          String?  @map("subject") @db.VarChar(50)
-  identifier       BigInt?  @db.BigInt
-  newValue         Json?    @map("new_value") @db.Json
-  oldValue         Json?    @map("old_value") @db.Json
-  user             User?    @relation(fields: [userId], references: [id], onDelete: Restrict, map: "audit_logs_users_id_fk")
+  id         BigInt   @id(map: "audit_logs_pk") @default(autoincrement()) @db.BigInt
+  message    String?  @db.VarChar(300)
+  userId     BigInt?  @map("user") @db.BigInt
+  timestamp  DateTime @default(now()) @db.Timestamp(6)
+  subject    String?  @map("subject") @db.VarChar(50)
+  identifier BigInt?  @db.BigInt
+  newValue   Json?    @map("new_value") @db.Json
+  oldValue   Json?    @map("old_value") @db.Json
+  user       User?    @relation(fields: [userId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "audit_logs_users_id_fk")
 
   @@index([timestamp], map: "audit_logs_timestamp_index")
   @@index([userId, timestamp], map: "audit_logs_userId_timestamp_index")
@@ -76,13 +76,13 @@ model AuditLog {
 }
 
 model BlogPost {
-  id                BigInt   @db.BigInt @id(map: "blog_pk") @default(autoincrement())
+  id                BigInt   @id(map: "blog_pk") @default(autoincrement()) @db.BigInt
   postedAt          DateTime @default(now()) @map("posted_at") @db.Timestamp(6)
   content           String
-  authorId          BigInt   @db.BigInt @map("author")
+  authorId          BigInt?  @map("author") @db.BigInt
   authorDisplayName String?  @map("author_display_name") @db.VarChar(100)
   title             String   @db.VarChar(150)
-  author            Person   @relation(fields: [authorId], references: [id], map: "blog_people_id_fk")
+  author            Person?  @relation(fields: [authorId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "blog_people_id_fk")
 
   @@index([authorId, postedAt], map: "blog_posts_author_posted_at_index")
   @@index([authorDisplayName, postedAt], map: "blog_posts_author_display_name_posted_at_index")
@@ -92,11 +92,11 @@ model BlogPost {
 }
 
 model Category {
-  id          BigInt       @db.BigInt @id(map: "categories_pk") @default(autoincrement())
+  id          BigInt       @id(map: "categories_pk") @default(autoincrement()) @db.BigInt
   name        String?      @db.VarChar(50)
   priority    Int          @default(0)
-  parentId    BigInt?      @db.BigInt @map("parent")
-  parent      Category?    @relation("CategoryToCategory_parentId", fields: [parentId], references: [id], onDelete: Restrict, map: "categories_categories_id_fk")
+  parentId    BigInt?      @map("parent") @db.BigInt
+  parent      Category?    @relation("CategoryToCategory_parentId", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "categories_categories_id_fk")
   children    Category[]   @relation("CategoryToCategory_parentId")
   productions Production[]
 
@@ -107,7 +107,7 @@ model Category {
 }
 
 model ContactSubmission {
-  id             BigInt   @db.BigInt @id(map: "contact_submissions_pk") @unique(map: "contact_submissions_id_uindex") @default(autoincrement())
+  id             BigInt   @id(map: "contact_submissions_pk") @unique(map: "contact_submissions_id_uindex") @default(autoincrement()) @db.BigInt
   email          String   @db.VarChar(300)
   name           String   @db.VarChar(100)
   subject        String   @db.VarChar(100)
@@ -125,13 +125,13 @@ model ContactSubmission {
 }
 
 model Credit {
-  productionId BigInt     @db.BigInt @map("production")
-  personId     BigInt     @db.BigInt @map("person")
+  productionId BigInt     @map("production") @db.BigInt
+  personId     BigInt     @map("person") @db.BigInt
   title        String?    @db.VarChar(100)
   priority     Int        @default(0)
-  id           BigInt     @db.BigInt @id(map: "credits_pk") @default(autoincrement())
-  person       Person     @relation(fields: [personId], references: [id], map: "credits_people_id_fk")
-  production   Production @relation(fields: [productionId], references: [id], map: "credits_productions_id_fk")
+  id           BigInt     @id(map: "credits_pk") @default(autoincrement()) @db.BigInt
+  person       Person     @relation(fields: [personId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "credits_people_id_fk")
+  production   Production @relation(fields: [productionId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "credits_productions_id_fk")
 
   @@unique([productionId, personId], map: "credits_pk_2")
   @@index([personId, productionId], map: "credits_person_production_index")
@@ -140,14 +140,14 @@ model Credit {
 }
 
 model Group {
-  id                BigInt            @db.BigInt @id(map: "groups_pk") @default(autoincrement())
-  name              String            @db.VarChar(50)
-  parentId          BigInt?           @db.BigInt @map("parent")
-  priority          Int               @default(0)
-  parent            Group?            @relation("GroupToGroup_parentId", fields: [parentId], references: [id], onDelete: Restrict, map: "groups_groups_id_fk")
-  permissions       GroupPermission[] @relation("group_permissionsTogroups")
-  children          Group[]           @relation("GroupToGroup_parentId")
-  users             UserGroup[]       @relation("groupsTouser_groups")
+  id          BigInt            @id(map: "groups_pk") @default(autoincrement()) @db.BigInt
+  name        String            @db.VarChar(50)
+  parentId    BigInt?           @map("parent") @db.BigInt
+  priority    Int               @default(0)
+  parent      Group?            @relation("GroupToGroup_parentId", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "groups_groups_id_fk")
+  permissions GroupPermission[] @relation("group_permissionsTogroups")
+  children    Group[]           @relation("GroupToGroup_parentId")
+  users       UserGroup[]       @relation("groupsTouser_groups")
 
   @@index([parentId, priority, name], map: "groups_parent_priority_name_index")
   @@index([priority, name], map: "groups_priority_name_index")
@@ -157,15 +157,15 @@ model Group {
 }
 
 model GroupPermission {
-  id         BigInt   @db.BigInt @id(map: "group_permissions_pk") @default(autoincrement())
-  groupId    BigInt   @db.BigInt @map("group")
+  id         BigInt   @id(map: "group_permissions_pk") @default(autoincrement()) @db.BigInt
+  groupId    BigInt   @map("group") @db.BigInt
   action     String   @db.VarChar(100)
   subject    String[] @db.VarChar(300)
   fields     String[] @db.VarChar(100)
   conditions Json?    @db.Json
   inverted   Boolean  @default(false)
   reason     String?  @db.VarChar(300)
-  group      Group    @relation("group_permissionsTogroups", fields: [groupId], references: [id], map: "group_permissions_groups_id_fk")
+  group      Group    @relation("group_permissionsTogroups", fields: [groupId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "group_permissions_groups_id_fk")
 
   @@index([groupId, subject, action], map: "group_permissions_group_subject_action_index")
   @@index([groupId, action, subject], map: "group_permissions_group_action_subject_index")
@@ -175,7 +175,7 @@ model GroupPermission {
 }
 
 model Image {
-  id                BigInt            @db.BigInt @id(map: "images_pk") @unique(map: "images_id_uindex") @default(autoincrement())
+  id                BigInt            @id(map: "images_pk") @unique(map: "images_id_uindex") @default(autoincrement()) @db.BigInt
   name              String            @db.VarChar(50)
   description       String?           @db.VarChar(200)
   path              String            @db.VarChar(1000)
@@ -190,12 +190,12 @@ model Image {
 }
 
 model Person {
-  id               BigInt        @db.BigInt @id(map: "people_pk") @unique(map: "people_id_uindex") @default(autoincrement())
+  id               BigInt        @id(map: "people_pk") @unique(map: "people_id_uindex") @default(autoincrement()) @db.BigInt
   name             String        @db.VarChar(100)
   pronouns         String?       @db.VarChar(20)
   graduation       DateTime?     @db.Date
-  profilePictureId BigInt?       @db.BigInt @map("profile_picture")
-  profilePicture   Image?        @relation(fields: [profilePictureId], references: [id], map: "people_images_id_fk")
+  profilePictureId BigInt?       @map("profile_picture") @db.BigInt
+  profilePicture   Image?        @relation(fields: [profilePictureId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "people_images_id_fk")
   description      String?
   blogPosts        BlogPost[]
   credits          Credit[]
@@ -209,12 +209,12 @@ model Person {
 }
 
 model PersonImage {
-  imageId  BigInt @db.BigInt @map("image")
-  personId BigInt @db.BigInt @map("person")
+  imageId  BigInt @map("image") @db.BigInt
+  personId BigInt @map("person") @db.BigInt
   priority Int    @default(0)
-  id       BigInt @db.BigInt @id(map: "people_images_pk") @default(autoincrement())
-  image    Image  @relation(fields: [imageId], references: [id], map: "people_images_images_id_fk")
-  person   Person @relation(fields: [personId], references: [id], map: "people_images_people_id_fk")
+  id       BigInt @id(map: "people_images_pk") @default(autoincrement()) @db.BigInt
+  image    Image  @relation(fields: [imageId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "people_images_images_id_fk")
+  person   Person @relation(fields: [personId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "people_images_people_id_fk")
 
   @@unique([imageId, personId], map: "people_images_pk_2")
   @@index([personId], map: "people_images_person_index")
@@ -222,13 +222,13 @@ model PersonImage {
 }
 
 model PersonRole {
-  id        BigInt    @db.BigInt @id(map: "people_roles_pk") @default(autoincrement())
-  personId  BigInt    @db.BigInt @map("person")
-  roleId    BigInt    @db.BigInt @map("role")
+  id        BigInt    @id(map: "people_roles_pk") @default(autoincrement()) @db.BigInt
+  personId  BigInt    @map("person") @db.BigInt
+  roleId    BigInt    @map("role") @db.BigInt
   startTime DateTime  @default(now()) @map("start_time") @db.Timestamp(6)
   endTime   DateTime? @map("end_time") @db.Timestamp(6)
-  person    Person    @relation(fields: [personId], references: [id], map: "people_roles_people_id_fk")
-  role      Role      @relation(fields: [roleId], references: [id], map: "people_roles_roles_id_fk")
+  person    Person    @relation(fields: [personId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "people_roles_people_id_fk")
+  role      Role      @relation(fields: [roleId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "people_roles_roles_id_fk")
 
   @@index([personId, startTime], map: "people_roles_person_start_time_index")
   @@index([roleId, startTime], map: "people_roles_role_start_time_index")
@@ -237,21 +237,21 @@ model PersonRole {
 }
 
 model Production {
-  id             BigInt            @db.BigInt @id(map: "productions_pk") @default(autoincrement())
+  id             BigInt            @id(map: "productions_pk") @default(autoincrement()) @db.BigInt
   name           String            @db.VarChar(100)
   description    String?
   startTime      DateTime?         @map("start_time") @db.Timestamp(6)
   endTime        DateTime?         @map("end_time") @db.Timestamp(6)
-  categoryId     BigInt?           @db.BigInt @map("category")
+  categoryId     BigInt?           @map("category") @db.BigInt
   closetLocation String?           @map("closet_location") @db.VarChar(100)
   eventLocation  String?           @map("event_location") @db.VarChar(100)
   teamNotes      String?           @map("team_notes")
   discordServer  String?           @map("discord_server") @db.Char(18)
   discordChannel String?           @map("discord_channel") @db.Char(18)
-  thumbnailId    BigInt?           @db.BigInt @map("thumbnail")
+  thumbnailId    BigInt?           @map("thumbnail") @db.BigInt
   closetTime     DateTime?         @map("closet_time") @db.Timestamp(6)
-  category       Category?         @relation(fields: [categoryId], references: [id], onDelete: Restrict, map: "productions_categories_id_fk")
-  thumbnail      Image?            @relation(fields: [thumbnailId], references: [id], onDelete: Restrict, map: "productions_images_id_fk")
+  category       Category?         @relation(fields: [categoryId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "productions_categories_id_fk")
+  thumbnail      Image?            @relation(fields: [thumbnailId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "productions_images_id_fk")
   credits        Credit[]
   images         ProductionImage[] @relation("production_imagesToproductions")
   rsvps          ProductionRSVP[]
@@ -265,12 +265,12 @@ model Production {
 }
 
 model ProductionImage {
-  productionId BigInt     @db.BigInt @map("production")
-  imageId      BigInt     @db.BigInt @map("image")
+  productionId BigInt     @map("production") @db.BigInt
+  imageId      BigInt     @map("image") @db.BigInt
   priority     Int        @default(0)
-  id           BigInt     @db.BigInt @id(map: "production_images_pk") @default(autoincrement())
-  image        Image      @relation(fields: [imageId], references: [id], map: "production_images_images_id_fk")
-  production   Production @relation("production_imagesToproductions", fields: [productionId], references: [id], map: "production_images_productions_id_fk")
+  id           BigInt     @id(map: "production_images_pk") @default(autoincrement()) @db.BigInt
+  image        Image      @relation(fields: [imageId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_images_images_id_fk")
+  production   Production @relation("production_imagesToproductions", fields: [productionId], onDelete: Cascade, onUpdate: Cascade, references: [id], map: "production_images_productions_id_fk")
 
   @@unique([productionId, imageId], map: "production_images_pk_2")
   @@index([productionId, imageId, priority], map: "production_images_production_image_priority_index")
@@ -280,13 +280,13 @@ model ProductionImage {
 }
 
 model ProductionRSVP {
-  productionId BigInt     @db.BigInt @map("production")
-  userId       BigInt     @db.BigInt @map("user")
+  productionId BigInt     @map("production") @db.BigInt
+  userId       BigInt     @map("user") @db.BigInt
   willAttend   String?    @map("will_attend") @db.VarChar(5)
   notes        String?
-  id           BigInt     @db.BigInt @id(map: "production_rsvps_pk") @default(autoincrement())
-  production   Production @relation(fields: [productionId], references: [id], map: "production_rsvps_productions_id_fk")
-  user         User       @relation(fields: [userId], references: [id], map: "production_rsvps_users_id_fk")
+  id           BigInt     @id(map: "production_rsvps_pk") @default(autoincrement()) @db.BigInt
+  production   Production @relation(fields: [productionId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_rsvps_productions_id_fk")
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_rsvps_users_id_fk")
 
   @@unique([productionId, userId], map: "production_rsvps_pk_2")
   @@index([productionId, userId, willAttend], map: "production_rsvps_production_user_will_attend_index")
@@ -296,10 +296,10 @@ model ProductionRSVP {
 }
 
 model ProductionTag {
-  productionId BigInt     @db.BigInt @map("production")
+  productionId BigInt     @map("production") @db.BigInt
   tag          String     @db.VarChar(50)
-  id           BigInt     @db.BigInt @id(map: "production_tags_pk") @default(autoincrement())
-  production   Production @relation(fields: [productionId], references: [id], map: "production_tags_productions_id_fk")
+  id           BigInt     @id(map: "production_tags_pk") @default(autoincrement()) @db.BigInt
+  production   Production @relation(fields: [productionId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_tags_productions_id_fk")
 
   @@unique([productionId, tag], map: "production_tags_pk_2")
   @@index([tag], map: "production_tags_tag_index")
@@ -307,12 +307,12 @@ model ProductionTag {
 }
 
 model ProductionVideo {
-  productionId BigInt     @db.BigInt @map("production")
-  videoId      BigInt     @db.BigInt @map("video")
+  productionId BigInt     @map("production") @db.BigInt
+  videoId      BigInt     @map("video") @db.BigInt
   priority     Int        @default(0)
-  id           BigInt     @db.BigInt @id(map: "production_videos_pk") @default(autoincrement())
-  production   Production @relation(fields: [productionId], references: [id], map: "production_videos_productions_id_fk")
-  video        Video      @relation(fields: [videoId], references: [id], map: "production_videos_videos_id_fk")
+  id           BigInt     @id(map: "production_videos_pk") @default(autoincrement()) @db.BigInt
+  production   Production @relation(fields: [productionId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_videos_productions_id_fk")
+  video        Video      @relation(fields: [videoId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "production_videos_videos_id_fk")
 
   @@unique([productionId, videoId], map: "production_videos_pk_2")
   @@index([productionId, videoId, priority], map: "production_videos_production_video_priority_index")
@@ -325,7 +325,7 @@ model Redirect {
   key      String    @unique(map: "redirects_pk_2") @db.VarChar(100)
   location String    @db.VarChar(3000)
   expires  DateTime? @db.Timestamp(6)
-  id       BigInt    @db.BigInt @id(map: "redirects_pk") @default(autoincrement())
+  id       BigInt    @id(map: "redirects_pk") @default(autoincrement()) @db.BigInt
 
   @@index([key, expires], map: "redirects_key_expires_index")
   @@index([expires], map: "redirects_expires_index")
@@ -334,11 +334,11 @@ model Redirect {
 }
 
 model Role {
-  id                  BigInt       @db.BigInt @id(map: "roles_pk") @default(autoincrement())
+  id                  BigInt       @id(map: "roles_pk") @default(autoincrement()) @db.BigInt
   name                String       @db.VarChar(100)
   description         String?      @db.VarChar(1000)
-  displayInMembership Boolean      @db.Boolean @default(false) @map("display_in_membership")
-  displayInLeadership Boolean      @db.Boolean @default(false) @map("display_in_leadership")
+  displayInMembership Boolean      @default(false) @map("display_in_membership") @db.Boolean
+  displayInLeadership Boolean      @default(false) @map("display_in_leadership") @db.Boolean
   priority            Int          @default(0)
   people              PersonRole[]
 
@@ -347,21 +347,21 @@ model Role {
 }
 
 model User {
-  id                         BigInt           @db.BigInt @id(map: "users_pk") @default(autoincrement())
-  username                   String           @unique(map: "users_username_uindex") @db.VarChar(8)
-  mail                       String           @unique(map: "users_mail_uindex") @db.VarChar(300)
-  personId                   BigInt?          @db.BigInt @map("person")
-  discord                    String?          @unique(map: "users_discord_uindex") @db.Char(18)
-  password                   String?          @db.VarChar(300)
-  joined                     DateTime         @default(now()) @db.Timestamp(6)
-  person                     Person?          @relation(fields: [personId], references: [id], onDelete: Restrict, map: "users_people_id_fk")
-  accessLogs                 AccessLog[]
-  checkedOutAssets           Asset[]          @relation("assetsTousers")
-  auditLogs                  AuditLog[]
-  productionRsvps            ProductionRSVP[]
-  groups                     UserGroup[]      @relation("user_groupsTousers")
-  permissions                UserPermission[] @relation("user_permissionsTousers")
-  voteResponses              VoteResponse[]
+  id               BigInt           @id(map: "users_pk") @default(autoincrement()) @db.BigInt
+  username         String           @unique(map: "users_username_uindex") @db.VarChar(8)
+  mail             String           @unique(map: "users_mail_uindex") @db.VarChar(300)
+  personId         BigInt?          @map("person") @db.BigInt
+  discord          String?          @unique(map: "users_discord_uindex") @db.Char(18)
+  password         String?          @db.VarChar(300)
+  joined           DateTime         @default(now()) @db.Timestamp(6)
+  person           Person?          @relation(fields: [personId], references: [id], onDelete: SetNull, onUpdate: Cascade, map: "users_people_id_fk")
+  accessLogs       AccessLog[]
+  checkedOutAssets Asset[]          @relation("assetsTousers")
+  auditLogs        AuditLog[]
+  productionRsvps  ProductionRSVP[]
+  groups           UserGroup[]      @relation("user_groupsTousers")
+  permissions      UserPermission[] @relation("user_permissionsTousers")
+  voteResponses    VoteResponse[]
 
   @@index([personId], map: "users_person_index")
   @@index([joined], map: "users_joined_index")
@@ -369,11 +369,11 @@ model User {
 }
 
 model UserGroup {
-  id      BigInt @db.BigInt @id(map: "user_groups_pk") @default(autoincrement())
-  userId  BigInt @db.BigInt @map("user")
-  groupId BigInt @db.BigInt @map("group")
-  group   Group  @relation("groupsTouser_groups", fields: [groupId], references: [id], map: "user_groups_groups_id_fk")
-  user    User   @relation("user_groupsTousers", fields: [userId], references: [id], map: "user_groups_users_id_fk")
+  id      BigInt @id(map: "user_groups_pk") @default(autoincrement()) @db.BigInt
+  userId  BigInt @map("user") @db.BigInt
+  groupId BigInt @map("group") @db.BigInt
+  group   Group  @relation("groupsTouser_groups", fields: [groupId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "user_groups_groups_id_fk")
+  user    User   @relation("user_groupsTousers", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "user_groups_users_id_fk")
 
   @@unique([userId, groupId], map: "user_groups_pk_2")
   @@index([groupId, userId], map: "user_groups_group_user_index")
@@ -381,15 +381,15 @@ model UserGroup {
 }
 
 model UserPermission {
-  id         BigInt   @db.BigInt @id(map: "user_permissions_pk") @default(autoincrement())
-  userId     BigInt   @db.BigInt @map("user")
+  id         BigInt   @id(map: "user_permissions_pk") @default(autoincrement()) @db.BigInt
+  userId     BigInt   @map("user") @db.BigInt
   action     String   @db.VarChar(100)
   subject    String[] @db.VarChar(300)
   fields     String[] @db.VarChar(100)
   conditions Json?    @db.Json
   inverted   Boolean  @default(false)
   reason     String?  @db.VarChar(300)
-  user       User     @relation("user_permissionsTousers", fields: [userId], references: [id], map: "user_permissions_users_id_fk")
+  user       User     @relation("user_permissionsTousers", fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "user_permissions_users_id_fk")
 
   @@index([userId, subject, action], map: "user_permissions_user_subject_action_index")
   @@index([userId, action, subject], map: "user_permissions_user_action_subject_index")
@@ -399,7 +399,7 @@ model UserPermission {
 }
 
 model Video {
-  id       BigInt            @db.BigInt @id(map: "videos_pk") @default(autoincrement())
+  id       BigInt            @id(map: "videos_pk") @default(autoincrement()) @db.BigInt
   name     String            @db.VarChar(100)
   format   String            @db.VarChar(32)
   metadata Json?             @db.Json
@@ -411,7 +411,7 @@ model Video {
 }
 
 model Vote {
-  id          BigInt         @db.BigInt @id(map: "votes_pk") @default(autoincrement())
+  id          BigInt         @id(map: "votes_pk") @default(autoincrement()) @db.BigInt
   question    String         @db.VarChar(200)
   options     String[]       @db.VarChar(200)
   expires     DateTime?      @db.Timestamp(6)
@@ -424,13 +424,13 @@ model Vote {
 }
 
 model VoteResponse {
-  voteId    BigInt   @db.BigInt @map("vote")
-  userId    BigInt   @db.BigInt @map("user")
+  voteId    BigInt   @map("vote") @db.BigInt
+  userId    BigInt   @map("user") @db.BigInt
   timestamp DateTime @default(now()) @db.Timestamp(6)
-  id        BigInt   @db.BigInt @id(map: "vote_responses_pk") @default(autoincrement())
+  id        BigInt   @id(map: "vote_responses_pk") @default(autoincrement()) @db.BigInt
   selection String   @db.VarChar(200)
-  user      User     @relation(fields: [userId], references: [id], map: "vote_responses_users_id_fk")
-  vote      Vote     @relation(fields: [voteId], references: [id], map: "vote_responses_votes_id_fk")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "vote_responses_users_id_fk")
+  vote      Vote     @relation(fields: [voteId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "vote_responses_votes_id_fk")
 
   @@unique([voteId, userId], map: "vote_responses_pk_2")
   @@index([voteId, userId, timestamp], map: "vote_responses_vote_user_timestamp_index")


### PR DESCRIPTION
Relational fields within the database were almost all set to the default of "No Action" on delete/update. This PR fixes that by making all optional fields set to null on delete, and all required fields cascade on delete. Updates cascade for all relations, however that shouldn't be relevant since Glimpse never updates IDs.

One problem introduced by this is that cascaded rows now won't show up as deleted/updated in audit logs. It also means that users can get around their permissions to delete/update on these types of rows. The best solution may be to manually implement cascading within the code, rather than having it fall back to the database, and then essentially revert this commit.

This PR also changes the blog post `author` field to not be required.

This PR will require a database migration.